### PR TITLE
Drop support of Julia 0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.5
   - 0.6
   # - nightly
 matrix:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,10 +1,10 @@
-julia 0.5
-Automa
+julia 0.6
+Automa 0.3
+BGZFStreams 0.1
 BioCore 1.0
 BioSequences 0.5
 BioSymbols 1.0
-BufferedStreams
-BGZFStreams
+BufferedStreams 0.3
 Compat 0.17
 GenomicFeatures 0.1
 IntervalTrees 0.2

--- a/REQUIRE
+++ b/REQUIRE
@@ -5,6 +5,5 @@ BioCore 1.0
 BioSequences 0.5
 BioSymbols 1.0
 BufferedStreams 0.3
-Compat 0.17
 GenomicFeatures 0.1
 IntervalTrees 0.2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,5 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/src/BioAlignments.jl
+++ b/src/BioAlignments.jl
@@ -88,7 +88,6 @@ export
 import BioCore: BioCore, distance, header, isfilled, seqname, hasseqname, sequence, hassequence, leftposition, rightposition, hasleftposition, hasrightposition
 import BioSequences
 import BioSymbols
-import Compat: @compat, take!
 import GenomicFeatures: eachoverlap
 import IntervalTrees
 

--- a/src/alignedseq.jl
+++ b/src/alignedseq.jl
@@ -6,7 +6,7 @@
 # This file is a part of BioJulia.
 # License is MIT: https://github.com/BioJulia/Bio.jl/blob/master/LICENSE.md
 
-immutable AlignedSequence{S}
+struct AlignedSequence{S}
     seq::S
     aln::Alignment
 end

--- a/src/alignment.jl
+++ b/src/alignment.jl
@@ -6,7 +6,7 @@
 # This file is a part of BioJulia.
 # License is MIT: https://github.com/BioJulia/Bio.jl/blob/master/LICENSE.md
 
-immutable Alignment
+struct Alignment
     anchors::Vector{AlignmentAnchor}
     firstref::Int
     lastref::Int

--- a/src/anchors.jl
+++ b/src/anchors.jl
@@ -15,7 +15,7 @@ It stores the position values as Int types and the alignment operation is stored
 as a type `Operation`, these are defined in the file `operations.jl` and loaded
 into BioAlignments namespace as a series of global constants.
 """
-immutable AlignmentAnchor
+struct AlignmentAnchor
     seqpos::Int
     refpos::Int
     op::Operation

--- a/src/bam/auxdata.jl
+++ b/src/bam/auxdata.jl
@@ -1,7 +1,7 @@
 # BAM Auxiliary Data
 # ==================
 
-immutable AuxData <: Associative{String,Any}
+struct AuxData <: Associative{String,Any}
     data::Vector{UInt8}
 end
 

--- a/src/bam/bai.jl
+++ b/src/bam/bai.jl
@@ -7,7 +7,7 @@
 # License is MIT: https://github.com/BioJulia/Bio.jl/blob/master/LICENSE.md
 
 # An index type for the BAM file format.
-type BAI
+struct BAI
     # BGZF file index
     index::GenomicFeatures.Indexes.BGZFIndex
 

--- a/src/bam/bam.jl
+++ b/src/bam/bam.jl
@@ -8,7 +8,6 @@ import BioAlignments: BioAlignments, SAM
 import GenomicFeatures: GenomicFeatures, Interval
 import BioSequences
 import BioCore: BioCore, isfilled
-import Compat: take!
 
 # FIXME
 const Bio = BioCore

--- a/src/bam/overlap.jl
+++ b/src/bam/overlap.jl
@@ -1,7 +1,7 @@
 # BAM Overlap
 # ===========
 
-immutable OverlapIterator{T}
+struct OverlapIterator{T}
     reader::Reader{T}
     refname::String
     interval::UnitRange{Int}
@@ -31,7 +31,7 @@ end
 # Iterator
 # --------
 
-type OverlapIteratorState
+mutable struct OverlapIteratorState
     # reference index
     refindex::Int
 

--- a/src/bam/reader.jl
+++ b/src/bam/reader.jl
@@ -10,7 +10,7 @@ Create a data reader of the BAM file format.
 * `input`: data source
 * `index=nothing`: filepath to a random access index (currently *bai* is Supported)
 """
-type Reader{T} <: Bio.IO.AbstractReader
+mutable struct Reader{T} <: Bio.IO.AbstractReader
     stream::BGZFStreams.BGZFStream{T}
     header::SAM.Header
     start_offset::BGZFStreams.VirtualOffset

--- a/src/bam/record.jl
+++ b/src/bam/record.jl
@@ -6,7 +6,7 @@
 
 Create an unfilled BAM record.
 """
-type Record
+mutable struct Record
     # fixed-length fields (see BMA specs for the details)
     block_size::Int32
     refid::Int32

--- a/src/bam/writer.jl
+++ b/src/bam/writer.jl
@@ -10,7 +10,7 @@ Create a data writer of the BAM file format.
 * `output`: data sink
 * `header`: SAM header object
 """
-type Writer <: Bio.IO.AbstractWriter
+mutable struct Writer <: Bio.IO.AbstractWriter
     stream::BGZFStreams.BGZFStream
 end
 

--- a/src/models.jl
+++ b/src/models.jl
@@ -50,7 +50,7 @@ mutable struct AffineGapScoreModel{T} <: AbstractScoreModel{T}
     gap_open::T
     gap_extend::T
 
-    function (::Type{AffineGapScoreModel{T}}){T}(submat::AbstractSubstitutionMatrix{T}, gap_open::T, gap_extend::T)
+    function AffineGapScoreModel{T}(submat::AbstractSubstitutionMatrix{T}, gap_open::T, gap_extend::T) where T
         @assert gap_open ≤ 0 "gap_open should be non-positive"
         @assert gap_extend ≤ 0 "gap_extend should be non-positive"
         return new{T}(submat, gap_open, gap_extend)
@@ -156,7 +156,7 @@ mutable struct CostModel{T} <: AbstractCostModel{T}
     insertion::T
     deletion::T
 
-    function (::Type{CostModel{T}}){T}(submat, insertion, deletion)
+    function CostModel{T}(submat, insertion, deletion) where T
         @assert insertion ≥ 0 "insertion should be non-negative"
         @assert deletion ≥ 0 " deletion should be non-negative"
         return new{T}(submat, insertion, deletion)

--- a/src/models.jl
+++ b/src/models.jl
@@ -13,7 +13,7 @@
 """
 Supertype of score model.
 """
-@compat abstract type AbstractScoreModel{T<:Real} end
+abstract type AbstractScoreModel{T<:Real} end
 
 """
     AffineGapScoreModel(submat, gap_open, gap_extend)
@@ -45,7 +45,7 @@ Example
 
 See also: `SubstitutionMatrix`, `pairalign`, `CostModel`
 """
-type AffineGapScoreModel{T} <: AbstractScoreModel{T}
+mutable struct AffineGapScoreModel{T} <: AbstractScoreModel{T}
     submat::AbstractSubstitutionMatrix{T}
     gap_open::T
     gap_extend::T
@@ -123,7 +123,7 @@ end
 """
 Supertype of cost model.
 """
-@compat abstract type AbstractCostModel{T} end
+abstract type AbstractCostModel{T} end
 
 """
     CostModel(submat, insertion, deletion)
@@ -151,7 +151,7 @@ Example
 
 See also: `SubstitutionMatrix`, `pairalign`, `AffineGapScoreModel`
 """
-type CostModel{T} <: AbstractCostModel{T}
+mutable struct CostModel{T} <: AbstractCostModel{T}
     submat::AbstractSubstitutionMatrix{T}
     insertion::T
     deletion::T

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -7,7 +7,7 @@
 # License is MIT: https://github.com/BioJulia/Bio.jl/blob/master/LICENSE.md
 
 # An alignment operation type
-@compat primitive type Operation 8 end
+primitive type Operation 8 end
 
 
 # Conversion to and from integers

--- a/src/pairwise/algorithms/banded_needleman_wunsch.jl
+++ b/src/pairwise/algorithms/banded_needleman_wunsch.jl
@@ -17,9 +17,9 @@ mutable struct BandedNeedlemanWunsch{T<:Union{Signed,AbstractFloat}}
     lower::Int
     upper::Int
 
-    function (::Type{BandedNeedlemanWunsch{T}}){T}(
+    function BandedNeedlemanWunsch{T}(
             m::Integer, n::Integer,
-            lower::Integer, upper::Integer)
+            lower::Integer, upper::Integer) where T
         lower = min(lower, m)
         upper = min(upper, n)
         width = lower + upper + 1
@@ -29,7 +29,7 @@ mutable struct BandedNeedlemanWunsch{T<:Union{Signed,AbstractFloat}}
         return new{T}(trace, H, E, lower, upper)
     end
 
-    function (::Type{BandedNeedlemanWunsch{T}}){T}()
+    function BandedNeedlemanWunsch{T}() where T
         return BandedNeedlemanWunsch{T}(0, 0, 0, 0)
     end
 end

--- a/src/pairwise/algorithms/banded_needleman_wunsch.jl
+++ b/src/pairwise/algorithms/banded_needleman_wunsch.jl
@@ -10,7 +10,7 @@
 # This file is a part of BioJulia.
 # License is MIT: https://github.com/BioJulia/Bio.jl/blob/master/LICENSE.md
 
-type BandedNeedlemanWunsch{T<:Union{Signed,AbstractFloat}}
+mutable struct BandedNeedlemanWunsch{T<:Union{Signed,AbstractFloat}}
     trace::Matrix{Trace}
     H::Vector{T}
     E::Vector{T}

--- a/src/pairwise/algorithms/needleman_wunsch.jl
+++ b/src/pairwise/algorithms/needleman_wunsch.jl
@@ -6,7 +6,7 @@
 # This file is a part of BioJulia.
 # License is MIT: https://github.com/BioJulia/Bio.jl/blob/master/LICENSE.md
 
-type NeedlemanWunsch{T<:Union{Signed,AbstractFloat}}
+mutable struct NeedlemanWunsch{T<:Union{Signed,AbstractFloat}}
     trace::Matrix{Trace}
     H::Vector{T}
     E::Vector{T}

--- a/src/pairwise/algorithms/needleman_wunsch.jl
+++ b/src/pairwise/algorithms/needleman_wunsch.jl
@@ -11,7 +11,7 @@ mutable struct NeedlemanWunsch{T<:Union{Signed,AbstractFloat}}
     H::Vector{T}
     E::Vector{T}
 
-    function (::Type{NeedlemanWunsch{T}}){T}(m::Integer, n::Integer)
+    function NeedlemanWunsch{T}(m::Integer, n::Integer) where T
         trace = Matrix{Trace}(m + 1, n + 1)
         fill!(trace, 0xff)
         H = Vector{T}(m + 1)
@@ -19,7 +19,7 @@ mutable struct NeedlemanWunsch{T<:Union{Signed,AbstractFloat}}
         return new{T}(trace, H, E)
     end
 
-    function (::Type{NeedlemanWunsch{T}}){T}()
+    function NeedlemanWunsch{T}() where T
         return NeedlemanWunsch{T}(0, 0)
     end
 end

--- a/src/pairwise/algorithms/smith_waterman.jl
+++ b/src/pairwise/algorithms/smith_waterman.jl
@@ -11,7 +11,7 @@ mutable struct SmithWaterman{T<:Union{Signed,AbstractFloat}}
     H::Vector{T}
     E::Vector{T}
 
-    function (::Type{SmithWaterman{T}}){T}(m::Integer, n::Integer)
+    function SmithWaterman{T}(m::Integer, n::Integer) where T
         trace = Matrix{Trace}(m + 1, n + 1)
         fill!(trace, 0xff)
         H = Vector{T}(m + 1)
@@ -19,7 +19,7 @@ mutable struct SmithWaterman{T<:Union{Signed,AbstractFloat}}
         return new{T}(trace, H, E)
     end
 
-    function (::Type{SmithWaterman{T}}){T}()
+    function SmithWaterman{T}() where T
         return SmithWaterman{T}(0, 0)
     end
 end

--- a/src/pairwise/algorithms/smith_waterman.jl
+++ b/src/pairwise/algorithms/smith_waterman.jl
@@ -6,7 +6,7 @@
 # This file is a part of BioJulia.
 # License is MIT: https://github.com/BioJulia/Bio.jl/blob/master/LICENSE.md
 
-type SmithWaterman{T<:Union{Signed,AbstractFloat}}
+mutable struct SmithWaterman{T<:Union{Signed,AbstractFloat}}
     trace::Matrix{Trace}
     H::Vector{T}
     E::Vector{T}

--- a/src/pairwise/alignment.jl
+++ b/src/pairwise/alignment.jl
@@ -9,7 +9,7 @@
 """
 Pairwise alignment
 """
-type PairwiseAlignment{S1,S2}
+mutable struct PairwiseAlignment{S1,S2}
     a::AlignedSequence{S1}
     b::S2
 end

--- a/src/pairwise/result.jl
+++ b/src/pairwise/result.jl
@@ -21,7 +21,7 @@ function PairwiseAlignmentResult(value, isscore, seq, ref)
                                    Nullable(PairwiseAlignment(seq, ref)))
 end
 
-function (::Type{PairwiseAlignmentResult{S1,S2}}){S1,S2}(value, isscore)
+function PairwiseAlignmentResult{S1,S2}(value, isscore) where {S1,S2}
     return PairwiseAlignmentResult(value, isscore,
                                    Nullable{PairwiseAlignment{S1,S2}}())
 end

--- a/src/pairwise/result.jl
+++ b/src/pairwise/result.jl
@@ -9,7 +9,7 @@
 """
 Result of pairwise alignment
 """
-type PairwiseAlignmentResult{T,S1,S2}
+mutable struct PairwiseAlignmentResult{T,S1,S2}
     # alignment score/distance
     value::T
     isscore::Bool

--- a/src/sam/header.jl
+++ b/src/sam/header.jl
@@ -1,7 +1,7 @@
 # SAM Header
 # ==========
 
-immutable Header
+struct Header
     metainfo::Vector{MetaInfo}
 end
 

--- a/src/sam/metainfo.jl
+++ b/src/sam/metainfo.jl
@@ -1,7 +1,7 @@
 # SAM Meta-Information
 # ====================
 
-type MetaInfo
+mutable struct MetaInfo
     # data and filled range
     data::Vector{UInt8}
     filled::UnitRange{Int}

--- a/src/sam/reader.jl
+++ b/src/sam/reader.jl
@@ -1,7 +1,7 @@
 # SAM Reader
 # =========
 
-type Reader <: Bio.IO.AbstractReader
+mutable struct Reader <: Bio.IO.AbstractReader
     state::Bio.Ragel.State
     header::Header
 

--- a/src/sam/record.jl
+++ b/src/sam/record.jl
@@ -1,7 +1,7 @@
 # SAM Record
 # ==========
 
-type Record
+mutable struct Record
     # data and filled range
     data::Vector{UInt8}
     filled::UnitRange{Int}

--- a/src/sam/sam.jl
+++ b/src/sam/sam.jl
@@ -10,7 +10,6 @@ import BioCore.Exceptions: missingerror
 import BioCore.RecordHelper: unsafe_parse_decimal
 import BioCore: BioCore, isfilled
 import BioSequences
-import Compat: take!
 import BufferedStreams
 
 # FIXME

--- a/src/sam/writer.jl
+++ b/src/sam/writer.jl
@@ -10,7 +10,7 @@ Create a data writer of the SAM file format.
 * `output`: data sink
 * `header=Header()`: SAM header object
 """
-type Writer <: Bio.IO.AbstractWriter
+mutable struct Writer <: Bio.IO.AbstractWriter
     stream::IO
 
     function Writer(output::IO, header::Header=Header())

--- a/src/submat.jl
+++ b/src/submat.jl
@@ -13,12 +13,12 @@ The required method:
 
 * `Base.getindex(submat, x, y)`: substitution score/cost from `x` to `y`
 """
-@compat abstract type AbstractSubstitutionMatrix{S<:Real} end
+abstract type AbstractSubstitutionMatrix{S<:Real} end
 
 """
 Substitution matrix.
 """
-immutable SubstitutionMatrix{T,S} <: AbstractSubstitutionMatrix{S}
+struct SubstitutionMatrix{T,S} <: AbstractSubstitutionMatrix{S}
     # square substitution matrix
     data::Matrix{S}
     # score is defined or not
@@ -148,7 +148,7 @@ end
 """
 Dichotomous substitution matrix.
 """
-immutable DichotomousSubstitutionMatrix{S} <: AbstractSubstitutionMatrix{S}
+struct DichotomousSubstitutionMatrix{S} <: AbstractSubstitutionMatrix{S}
     match::S
     mismatch::S
 end

--- a/src/submat.jl
+++ b/src/submat.jl
@@ -24,7 +24,7 @@ struct SubstitutionMatrix{T,S} <: AbstractSubstitutionMatrix{S}
     # score is defined or not
     defined::BitMatrix
 
-    function (::Type{SubstitutionMatrix{T,S}}){T,S}(data::Matrix{S}, defined::BitMatrix)
+    function SubstitutionMatrix{T,S}(data::Matrix{S}, defined::BitMatrix) where {T,S}
         @assert size(data) == size(defined)
         @assert size(data, 1) == size(data, 2) == length(BioSymbols.alphabet(T)) - 1
         return new{T,S}(data, defined)

--- a/src/types.jl
+++ b/src/types.jl
@@ -6,30 +6,30 @@
 # This file is a part of BioJulia.
 # License is MIT: https://github.com/BioJulia/Bio.jl/blob/master/LICENSE.md
 
-@compat abstract type AbstractAlignment end
+abstract type AbstractAlignment end
 
 
 # Alignments
 # ----------
 
 """Global-global alignment with end gap penalties."""
-immutable GlobalAlignment <: AbstractAlignment end
+struct GlobalAlignment <: AbstractAlignment end
 
 """Global-local alignment."""
-immutable SemiGlobalAlignment <: AbstractAlignment end
+struct SemiGlobalAlignment <: AbstractAlignment end
 
 """Global-global alignment without end gap penalties."""
-immutable OverlapAlignment <: AbstractAlignment end
+struct OverlapAlignment <: AbstractAlignment end
 
 """Local-local alignment."""
-immutable LocalAlignment <: AbstractAlignment end
+struct LocalAlignment <: AbstractAlignment end
 
 
 # Distances
 # ---------
 
 """Edit distance."""
-immutable EditDistance <: AbstractAlignment end
+struct EditDistance <: AbstractAlignment end
 
 """
 Levenshtein distance.
@@ -37,7 +37,7 @@ Levenshtein distance.
 A special case of `EditDistance` with the costs of mismatch, insertion, and
 deletion are 1.
 """
-immutable LevenshteinDistance <: AbstractAlignment end
+struct LevenshteinDistance <: AbstractAlignment end
 
 """
 Hamming distance.
@@ -45,4 +45,4 @@ Hamming distance.
 A special case of `EditDistance` with the costs of insertion and deletion are
 infinitely large.
 """
-immutable HammingDistance <: AbstractAlignment end
+struct HammingDistance <: AbstractAlignment end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,6 @@ using BioSymbols
 import BGZFStreams: BGZFStream
 import BioCore.Exceptions: MissingFieldException
 import BioSequences: @dna_str
-import Compat: take!
 import GenomicFeatures
 import YAML
 


### PR DESCRIPTION
This drops support of Julia 0.5 because it is tedious to support both Julia versions. Since BioAlignments.jl 0.1 already exists, users still can use this package on Julia 0.5.