### PR TITLE
Adjust some dependency lower bounds

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,9 +1,9 @@
 julia 0.6
-Automa 0.3
-BGZFStreams 0.1
+Automa 0.1
+BGZFStreams 0.0.1
 BioCore 1.0
-BioSequences 0.5
+BioSequences 0.6
 BioSymbols 1.0
 BufferedStreams 0.3
 GenomicFeatures 0.1
-IntervalTrees 0.2
+IntervalTrees 0.1


### PR DESCRIPTION
tests seem to pass here all the way down to Automa v0.1.0, BGZFStreams v0.0.1,
and IntervalTrees v0.1.0 (though that would require using older GenomicFeatures,
and the lower bounds of GenomicFeatures' dependency on IntervalTrees might be too tight)

BioSequences v0.5.0 doesn't load on Julia 0.6