### PR TITLE
Add flag test for alignment to the positive strand

### DIFF
--- a/docs/src/references.md
+++ b/docs/src/references.md
@@ -152,6 +152,7 @@ BAM.Record
 BAM.flag
 BAM.ismapped
 BAM.isprimary
+BAM.ispositivestrand
 BAM.refid
 BAM.refname
 BAM.position

--- a/src/bam/record.jl
+++ b/src/bam/record.jl
@@ -128,6 +128,17 @@ function isprimary(record::Record)::Bool
 end
 
 """
+    ispositivestrand(record::Record)::Bool
+
+Test if `record` is aligned to the positive strand.
+
+This is equivalent to `flag(record) & 0x10 == 0`.
+"""
+function ispositivestrand(record::Record)::Bool
+    flag(record) & 0x10 == 0
+end
+
+"""
     refid(record::Record)::Int
 
 Get the reference sequence ID of `record`.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -495,7 +495,7 @@ end
     @testset "count_<ops>" begin
         # anchors are derived from an alignment:
         #   seq: ACG---TGCAGAATTT
-        #        |     || || ||
+        #        |     || || ||  
         #   ref: AAAATTTGAAGTAT--
         a = dna"ACGTGCAGAATTT"
         b = dna"AAAATTTGAAGTAT"
@@ -856,13 +856,13 @@ end
                 """)
 
                 testaln("""
-                 ACGT
+                 ACGT  
                 AACGTTT
                  ^^^^
                 """)
 
                 testaln("""
-                  AC-GT
+                  AC-GT  
                 AAACTGTTT
                 """)
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -495,7 +495,7 @@ end
     @testset "count_<ops>" begin
         # anchors are derived from an alignment:
         #   seq: ACG---TGCAGAATTT
-        #        |     || || ||  
+        #        |     || || ||
         #   ref: AAAATTTGAAGTAT--
         a = dna"ACGTGCAGAATTT"
         b = dna"AAAATTTGAAGTAT"
@@ -856,13 +856,13 @@ end
                 """)
 
                 testaln("""
-                 ACGT  
+                 ACGT
                 AACGTTT
                  ^^^^
                 """)
 
                 testaln("""
-                  AC-GT  
+                  AC-GT
                 AAACTGTTT
                 """)
             end
@@ -1265,6 +1265,7 @@ end
         read!(reader, record)
         @test BAM.ismapped(record)
         @test BAM.isprimary(record)
+        @test ! BAM.ispositivestrand(record)
         @test BAM.refname(record) == "CHROMOSOME_I"
         @test BAM.refid(record) === 1
         @test BAM.hasnextrefid(record)


### PR DESCRIPTION
This PR implements `ispositivestrand()` which tests a BAM record flag to see if the read was mapped to the positive strand.

## Types of changes

This PR implements the following changes:
A new function with docstring and an addition to the docs that list the functions.

* [x] :sparkles: New feature (A non-breaking change which adds functionality).
* [ ] :bug: Bug fix (A non-breaking change, which fixes an issue).
* [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change).


## :ballot_box_with_check: Checklist

- [x] :art: The changes implemented is consistent with the [julia style guide](https://docs.julialang.org/en/stable/manual/style-guide/).
- [x] :blue_book: I have updated and added relevant docstrings, in a manner consistent with the [documentation styleguide](https://docs.julialang.org/en/stable/manual/documentation/).
- [x] :blue_book: I have added or updated relevant user and developer manuals/documentation in `docs/src/`.
- [x] :ok: There are unit tests that cover the code changes I have made.
- [x] :ok: The unit tests cover my code changes AND they pass.
- [ ] :pencil: I have added an entry to the `[UNRELEASED]` section of the manually curated `CHANGELOG.md` file for this repository.
- [x] :ok: All changes should be compatible with the latest stable version of Julia.
- [x] :thought_balloon: I have commented liberally for any complex pieces of internal code.
