### PR TITLE
:bug: Update covert(BAM.Record x::Vector{UInt8} to Julia v. 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Function convert(BAM.Record, x::Vector{UInt8} updated to Julia v. 1.0
 
 ## [1.0.0] - 2018-09-18
 ### Added

--- a/src/bam/record.jl
+++ b/src/bam/record.jl
@@ -34,11 +34,14 @@ function Record(data::Vector{UInt8})
 end
 
 function Base.convert(::Type{Record}, data::Vector{UInt8})
+    length(data) < FIXED_FIELDS_BYTES && throw(ArgumentError("data too short"))
     record = Record()
-    unsafe_copy!(pointer_from_objref(record), pointer(data), FIXED_FIELDS_BYTES)
+    dst_pointer = Ptr{UInt8}(pointer_from_objref(record))
+    unsafe_copyto!(dst_pointer, pointer(data), FIXED_FIELDS_BYTES)
     dsize = data_size(record)
     resize!(record.data, dsize)
-    unsafe_copy!(pointer(record.data), pointer(data, FIXED_FIELDS_BYTES + 1), dsize)
+    length(data) < dsize + FIXED_FIELDS_BYTES && throw(ArgumentError("data too short"))
+    unsafe_copyto!(record.data, 1, data, FIXED_FIELDS_BYTES + 1, dsize)
     return record
 end
 


### PR DESCRIPTION
Implement proposed solution in issue #22
Added test for the fixed function
Changed the format of some test cases which previously relied on trailing whitespace to work.

# Update covert(BAM.Record x::Vector{UInt8} to Julia v. 1.0
## Types of changes

This PR implements the following changes:
_(Please tick any or all of the following that are applicable)_

* [ ] :sparkles: New feature (A non-breaking change which adds functionality).
* :ballot_box_with_check: :bug: Bug fix (A non-breaking change, which fixes an issue).
* [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change).

## :clipboard: Additional detail

On current master, the function `convert(::Type{BAM.Record}, x::Vector{UInt8})` relies on the function `unsafe_copy!`, which does not exist in Julia 1.0. I have changed the function to use `unsafe_copyto!`, and also added checks on the length of the vector to make sure it doesn't segfault if given wrong data.

Furthermore, the function was not covered by tests. I have added new tests for the function.

Lastly, on current master, some unrelated test cases relies on trailing whitespace to succeed. I have reformatted them in a way so they do not contain trailing whitespace.

## :ballot_box_with_check: Checklist
This function is rarely called explicitly by the user, so I have not added documentation.

- :ballot_box_with_check: :art: The changes implemented is consistent with the [julia style guide](https://docs.julialang.org/en/stable/manual/style-guide/).
- :ballot_box_with_check: :blue_book: I have updated and added relevant docstrings, in a manner consistent with the [documentation styleguide](https://docs.julialang.org/en/stable/manual/documentation/).
- [ ] :blue_book: I have added or updated relevant user and developer manuals/documentation in `docs/src/`.
- :ballot_box_with_check: :ok: There are unit tests that cover the code changes I have made.
- :ballot_box_with_check: :ok: The unit tests cover my code changes AND they pass.
- :ballot_box_with_check: :pencil: I have added an entry to the `[UNRELEASED]` section of the manually curated `CHANGELOG.md` file for this repository.
- :ballot_box_with_check: :ok: All changes should be compatible with the latest stable version of Julia.
- :ballot_box_with_check: :thought_balloon: I have commented liberally for any complex pieces of internal code.
