### PR TITLE
Fix haskey(x::BAM.Record, y::String) (issue #20)

### DIFF
--- a/src/bam/auxdata.jl
+++ b/src/bam/auxdata.jl
@@ -7,7 +7,7 @@ end
 
 function Base.getindex(aux::AuxData, tag::AbstractString)
     checkauxtag(tag)
-    return getauxvalue(aux.data, 1, UInt8(tag[1]), UInt8(tag[2]))
+    return getauxvalue(aux.data, 1, length(aux.data), UInt8(tag[1]), UInt8(tag[2]))
 end
 
 function Base.length(aux::AuxData)
@@ -48,8 +48,8 @@ function checkauxtag(tag::AbstractString)
     end
 end
 
-function getauxvalue(data::Vector{UInt8}, pos::Int, t1::UInt8, t2::UInt8)
-    pos = findauxtag(data, pos, t1, t2)
+function getauxvalue(data::Vector{UInt8}, start::Int, stop::Int, t1::UInt8, t2::UInt8)
+    pos = findauxtag(data, start, stop, t1, t2)
     if pos == 0
         throw(KeyError(String([t1, t2])))
     end
@@ -104,11 +104,12 @@ function loadauxvalue(data::Vector{UInt8}, p::Int, ::Type{String})
     return q + 2, String(data[p:q])
 end
 
-function findauxtag(data::Vector{UInt8}, pos::Int, t1::UInt8, t2::UInt8)
-    while pos ≤ length(data) && !(data[pos] == t1 && data[pos+1] == t2)
+function findauxtag(data::Vector{UInt8}, start::Int, stop::Int, t1::UInt8, t2::UInt8)
+    pos = start
+    while pos ≤ stop && !(data[pos] == t1 && data[pos+1] == t2)
         pos = next_tag_position(data, pos)
     end
-    if pos > length(data)
+    if pos > stop
         return 0
     else
         return pos

--- a/src/bam/record.jl
+++ b/src/bam/record.jl
@@ -399,7 +399,9 @@ function cigar_position(record::Record, checkCG::Bool = true)::Tuple{Int, Int}
     if x != UInt32(seqlength(record) << 4 | 4)
         return cigaridx, nops
     end
-    tagidx = findauxtag(record.data, auxdata_position(record), UInt8('C'), UInt8('G'))
+    start = auxdata_position(record)
+    stop = data_size(record)
+    tagidx = findauxtag(record.data, start, stop, UInt8('C'), UInt8('G'))
     if tagidx == 0
         return cigaridx, nops
     end
@@ -563,12 +565,16 @@ end
 
 function Base.getindex(record::Record, tag::AbstractString)
     checkauxtag(tag)
-    return getauxvalue(record.data, auxdata_position(record), UInt8(tag[1]), UInt8(tag[2]))
+    start = auxdata_position(record)
+    stop = data_size(record)
+    return getauxvalue(record.data, start, stop, UInt8(tag[1]), UInt8(tag[2]))
 end
 
 function Base.haskey(record::Record, tag::AbstractString)
     checkauxtag(tag)
-    return findauxtag(record.data, auxdata_position(record), UInt8(tag[1]), UInt8(tag[2])) > 0
+    start = auxdata_position(record)
+    stop = data_size(record)
+    return findauxtag(record.data, start, stop, UInt8(tag[1]), UInt8(tag[2])) > 0
 end
 
 function Base.keys(record::Record)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -856,16 +856,9 @@ end
                   ^^
                 """)
 
-                testaln("""
-                 ACGT  
-                AACGTTT
-                 ^^^^
-                """)
+                testaln(" ACGT  \nAACGTTT\n ^^^^  ")
+                testaln("  AC-GT  \nAAACTGTTT")
 
-                testaln("""
-                  AC-GT  
-                AAACTGTTT
-                """)
             end
 
             @testset "no match" begin
@@ -1312,14 +1305,14 @@ end
             field_l = length(field_ops)
             return cigar_l, field_l
         end
-    
+
         function check_cigar_vs_field(rec::BAM.Record)
             cigar = BAM.cigar(rec)
             field = BAM.cigar(rec, false)
             cigar_l, field_l = get_cigar_lens(rec)
             return cigar != field && cigar_l != field_l
         end
-        
+
         function check_cigar_lens(rec::BAM.Record, field_len, cigar_len)
             cigar_l, field_l = get_cigar_lens(rec)
             return cigar_l == cigar_len && field_l == field_len


### PR DESCRIPTION
# Fixes a bug in haskey(x::BAM.Record, y::String)

## Types of changes

This PR implements the following changes:
_(Please tick any or all of the following that are applicable)_

* [ ] :sparkles: New feature (A non-breaking change which adds functionality).
* :ballot_box_with_check:  :bug: Bug fix (A non-breaking change, which fixes an issue).
* [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change).

## :clipboard: Additional detail
On current master, a BAM.Record's data field can be longer than the actual record's size. The actual size is accessed by `data_size(record)`, and any extra bytes are simply ignored. Except that the functions for accessing AUX keys directly from the records data field do not check the record's size. The result is that any extra bytes will be unparsable, resulting in an obscure error. See issue #20 .
Note that this problem does not occur when operating on AuxData objects, since `data_size(record)` is called when instantiating those.
To fix this problem, I have updated `findauxtag` and `getauxvalue` to use a stop keyword, indicating when there is no more data to be read. This number is found by a call to `data_size(record`) in the relevant places.

Also, I have changed an unrelated part of the test code which used to rely on trailing whitespace to work, potentially resulting in very annoying bugs.

## :ballot_box_with_check: Checklist
Since this is a pure internal bugfix, no documentation or tests has been changed.

- :ballot_box_with_check: :art: The changes implemented is consistent with the [julia style guide](https://docs.julialang.org/en/stable/manual/style-guide/).
- [ ] :blue_book: I have updated and added relevant docstrings, in a manner consistent with the [documentation styleguide](https://docs.julialang.org/en/stable/manual/documentation/).
- [ ] :blue_book: I have added or updated relevant user and developer manuals/documentation in `docs/src/`.
- :ballot_box_with_check: :ok: There are unit tests that cover the code changes I have made.
- :ballot_box_with_check: :ok: The unit tests cover my code changes AND they pass.
- :ballot_box_with_check: :pencil: I have added an entry to the `[UNRELEASED]` section of the manually curated `CHANGELOG.md` file for this repository.
- :ballot_box_with_check: :ok: All changes should be compatible with the latest stable version of Julia.
- :ballot_box_with_check: :thought_balloon: I have commented liberally for any complex pieces of internal code.
