### PR TITLE
Fix reading BAM files from processes.

### DIFF
--- a/src/bam/reader.jl
+++ b/src/bam/reader.jl
@@ -114,7 +114,7 @@ function init_bam_reader(input::BGZFStreams.BGZFStream)
         push!(refseqlens, seqlen)
     end
 
-    voffset = isa(input.io, Pipe) ?
+    voffset = isa(input.io, Base.AbstractPipe) ?
         BGZFStreams.VirtualOffset(0, 0) :
         BGZFStreams.virtualoffset(input)
     return Reader(


### PR DESCRIPTION
This just makes a check less restrictive so reading BAM files from processes works once again.