### PR TITLE
improve BAM.quality performance

### DIFF
--- a/src/bam/record.jl
+++ b/src/bam/record.jl
@@ -537,15 +537,15 @@ function hasseqlength(record::Record)
 end
 
 """
-    quality(record::Record)::Vector{UInt8}
+    quality(record::Record)
 
-Get the base quality of  `record`.
+Get the base quality of `record`.
 """
-function quality(record::Record)::Vector{UInt8}
+function quality(record::Record)
     checkfilled(record)
     seqlen = seqlength(record)
     offset = seqname_length(record) + n_cigar_op(record, false) * 4 + cld(seqlen, 2)
-    return [reinterpret(Int8, record.data[i+offset]) for i in 1:seqlen]
+    return record.data[(1+offset):(seqlen+offset)]
 end
 
 function hasquality(record::Record)


### PR DESCRIPTION
This removes the reinterpret and type assert from BAM.quality and instead returns a vector with the raw qualities from record.data, which improves performance a bit, specially when it comes to memory allocations:

```
Computing the average quality on 5M reads

Master:  17.907719 seconds (20.33 M allocations: 2.483 GiB, 3.22% gc time)
This PR: 16.474836 seconds (5.33  M allocations: 1.109 GiB, 1.03% gc time)
```

I've tested the change on bams produced by different aligners (bwa, bowtie & hisat2) and the retrieved qualities were identical. Fix #32 