### PR TITLE
@info instead of info

### DIFF
--- a/src/sam/reader.jl
+++ b/src/sam/reader.jl
@@ -49,7 +49,7 @@ end
 # file   = header . body
 # header = metainfo*
 # body   = record*
-isinteractive() && info("compiling SAM")
+isinteractive() && @info "compiling SAM"
 const sam_metainfo_machine, sam_record_machine, sam_header_machine, sam_body_machine = (function ()
     cat = Automa.RegExp.cat
     rep = Automa.RegExp.rep


### PR DESCRIPTION
This bug prevents `BioAlignments` and any other package that depends on it from being loaded in REPL or any other interactive environment.