### PR TITLE
Release/v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.0.0]
+
 ### Added
 - BioJulia registry.
 
@@ -55,7 +57,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.1.0] - 2017-06-30
 - This initial release extracted the alignment utilities out from Bio.jl into this dedicated package.
 
-[Unreleased]: https://github.com/BioJulia/BioAlignments.jl/compare/v1.0.1...HEAD
+[Unreleased]: https://github.com/BioJulia/BioAlignments.jl/compare/v2.0.0...HEAD
+[2.0.0]: https://github.com/BioJulia/BioAlignments.jl/compare/v1.0.1...v2.0.0
 [1.0.1]: https://github.com/BioJulia/BioAlignments.jl/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/BioJulia/BioAlignments.jl/compare/v0.3.0...v1.0.0
 [0.3.0]: https://github.com/BioJulia/BioAlignments.jl/compare/v0.2.0...v0.3.0

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BioAlignments"
 uuid = "00701ae9-d1dc-5365-b64a-a3a3ebf5695e"
 authors = ["Kenta Sato <bicycle1885@gmail.com>", "Ben J. Ward <benjward@protonmail.com>"]
-version = "1.0.1"
+version = "2.0.0"
 
 [deps]
 BioGenerics = "47718e42-2ac5-11e9-14af-e5595289c2ea" # Note: required for distance function.


### PR DESCRIPTION
This PR contains some breaking changes but moves towards separating package responsibilities and progresses https://github.com/BioJulia/BioAlignments.jl/issues/35.

### Added
- BioJulia registry.

### Changed
- Migrated from BioCore to [BioGenerics](https://github.com/BioJulia/BioGenerics.jl/tree/v0.1.0).
- Updated to use [BioSequences](https://github.com/BioJulia/BioSequences.jl/tree/v2.0.0) v2.
- Updated CI.

### Removed
- :exclamation: BAM and SAM submodules were moved to [XAM.jl](https://github.com/BioJulia/XAM.jl).
- :exclamation: Support for julia v0.7 and v1.0 was dropped.

cc @BenJWard, @bicycle1885 