### PR TITLE
Add alignment string position support

### DIFF
--- a/src/BioAlignments.jl
+++ b/src/BioAlignments.jl
@@ -21,8 +21,14 @@ export
     AlignmentAnchor,
     Alignment,
     AlignedSequence,
+
     seq2ref,
     ref2seq,
+    seq2aln,
+    ref2aln,
+    aln2seq,
+    aln2ref,
+
     ismatchop,
     isinsertop,
     isdeleteop,

--- a/src/alignedseq.jl
+++ b/src/alignedseq.jl
@@ -70,13 +70,8 @@ function IntervalTrees.last(alnseq::AlignedSequence)
     return alnseq.aln.lastref
 end
 
-function seq2ref(alnseq::AlignedSequence, i::Integer)
-    return seq2ref(alnseq.aln, i)
-end
-
-function ref2seq(alnseq::AlignedSequence, i::Integer)
-    return ref2seq(alnseq.aln, i)
-end
+seq2ref(alnseq::AlignedSequence, i) = seq2ref(alnseq.aln, i)
+ref2seq(alnseq::AlignedSequence, i) = ref2seq(alnseq.aln, i)
 
 # simple letters and dashes representation of an alignment
 function Base.show(io::IO, alnseq::AlignedSequence)

--- a/src/alignedseq.jl
+++ b/src/alignedseq.jl
@@ -27,6 +27,7 @@ function AlignedSequence(seq::BioSequences.BioSequence, seqpos::Integer,
     end
     seqpos -= 1
     refpos -= 1
+    alnpos = 0
     op = OP_START
     newseq = similar(seq, 0)  # sequence without gap symbols
     anchors = AlignmentAnchor[]
@@ -44,7 +45,7 @@ function AlignedSequence(seq::BioSequences.BioSequence, seqpos::Integer,
         end
 
         if op′ != op
-            push!(anchors, AlignmentAnchor(seqpos, refpos, op))
+            push!(anchors, AlignmentAnchor(seqpos, refpos, alnpos, op))
             op = op′
         end
 
@@ -55,8 +56,9 @@ function AlignedSequence(seq::BioSequences.BioSequence, seqpos::Integer,
         if y != BioSequences.gap(eltype(ref))
             refpos += 1
         end
+        alnpos += 1 # one or another don't have gap
     end
-    push!(anchors, AlignmentAnchor(seqpos, refpos, op))
+    push!(anchors, AlignmentAnchor(seqpos, refpos, alnpos, op))
     return AlignedSequence(newseq, anchors)
 end
 
@@ -72,6 +74,10 @@ end
 
 seq2ref(alnseq::AlignedSequence, i) = seq2ref(alnseq.aln, i)
 ref2seq(alnseq::AlignedSequence, i) = ref2seq(alnseq.aln, i)
+seq2aln(alnseq::AlignedSequence, i) = seq2aln(alnseq.aln, i)
+ref2aln(alnseq::AlignedSequence, i) = ref2aln(alnseq.aln, i)
+aln2seq(alnseq::AlignedSequence, i) = aln2seq(alnseq.aln, i)
+aln2ref(alnseq::AlignedSequence, i) = aln2ref(alnseq.aln, i)
 
 # simple letters and dashes representation of an alignment
 function Base.show(io::IO, alnseq::AlignedSequence)

--- a/src/alignment.jl
+++ b/src/alignment.jl
@@ -7,7 +7,9 @@
 # License is MIT: https://github.com/BioJulia/Bio.jl/blob/master/LICENSE.md
 
 """
-Alignment of two sequences.
+Defines how to align a given sequence onto a reference sequence.
+The alignment is represented as a sequence of elementary operations (match, insertion, deletion etc)
+anchored to specific positions of the input and reference sequence.
 """
 struct Alignment
     anchors::Vector{AlignmentAnchor}

--- a/src/alignment.jl
+++ b/src/alignment.jl
@@ -172,31 +172,30 @@ function check_alignment_anchors(anchors)
     end
 
     for i in 2:lastindex(anchors)
-        if anchors[i].refpos < anchors[i-1].refpos ||
-           anchors[i].seqpos < anchors[i-1].seqpos
+        @inbounds acur, aprev = anchors[i], anchors[i-1]
+        if acur.refpos < aprev.refpos || acur.seqpos < aprev.seqpos
             error("Alignment anchors must be sorted.")
         end
 
-        op = anchors[i].op
-        if convert(UInt8, op) > convert(UInt8, OP_MAX_VALID)
+        op = acur.op
+        if !isvalid(op)
             error("Anchor at index $(i) has an invalid operation.")
         end
 
         # reference skip/delete operations
         if isdeleteop(op)
-            if anchors[i].seqpos != anchors[i-1].seqpos
-                error("Invalid anchor positions for reference deletion.")
+            if acur.seqpos != aprev.seqpos
+                error("Invalid anchor sequence positions for reference deletion.")
             end
         # reference insertion operations
         elseif isinsertop(op)
-            if anchors[i].refpos != anchors[i-1].refpos
-                error("Invalid anchor positions for reference insertion.")
+            if acur.refpos != aprev.refpos
+                error("Invalid anchor reference positions for reference insertion.")
             end
         # match operations
         elseif ismatchop(op)
-            if anchors[i].refpos - anchors[i-1].refpos !=
-               anchors[i].seqpos - anchors[i-1].seqpos
-                error("Invalid anchor positions for match operation.")
+            if acur.refpos - aprev.refpos != acur.seqpos - aprev.seqpos
+               error("Invalid anchor positions for match operation.")
             end
         end
     end

--- a/src/anchors.jl
+++ b/src/anchors.jl
@@ -18,3 +18,6 @@ end
 function Base.show(io::IO, anc::AlignmentAnchor)
     print(io, "AlignmentAnchor(", anc.seqpos, ", ", anc.refpos, ", '", anc.op, "')")
 end
+
+seqpos(anc::AlignmentAnchor) = anc.seqpos
+refpos(anc::AlignmentAnchor) = anc.refpos

--- a/src/anchors.jl
+++ b/src/anchors.jl
@@ -15,10 +15,6 @@ struct AlignmentAnchor
     op::Operation
 end
 
-function AlignmentAnchor(pos::Tuple{Int,Int}, op)
-    return AlignmentAnchor(pos[1], pos[2], op)
-end
-
 function Base.show(io::IO, anc::AlignmentAnchor)
     print(io, "AlignmentAnchor(", anc.seqpos, ", ", anc.refpos, ", '", anc.op, "')")
 end

--- a/src/anchors.jl
+++ b/src/anchors.jl
@@ -12,12 +12,15 @@ Alignment operation with anchoring positions.
 struct AlignmentAnchor
     seqpos::Int
     refpos::Int
+    alnpos::Int
     op::Operation
-end
-
-function Base.show(io::IO, anc::AlignmentAnchor)
-    print(io, "AlignmentAnchor(", anc.seqpos, ", ", anc.refpos, ", '", anc.op, "')")
 end
 
 seqpos(anc::AlignmentAnchor) = anc.seqpos
 refpos(anc::AlignmentAnchor) = anc.refpos
+alnpos(anc::AlignmentAnchor) = anc.alnpos
+
+function Base.show(io::IO, anc::AlignmentAnchor)
+    print(io, "AlignmentAnchor(", anc.seqpos, ", ", anc.refpos,
+                               ", ", anc.alnpos, ", '", anc.op, "')")
+end

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -113,7 +113,7 @@ function Base.convert(::Type{Char}, op::Operation)
 end
 
 function Base.print(io::IO, op::Operation)
-    write(io, convert(Char, op))
+    write(io, isvalid(op) ? convert(Char, op) : '?')
     return
 end
 

--- a/src/pairwise/algorithms/common.jl
+++ b/src/pairwise/algorithms/common.jl
@@ -32,16 +32,32 @@ const TRACE_EXTINS = 0b10000
 
 macro start_traceback()
     esc(quote
-        anchor_point = (i, j)
+        __alnpos = 0
+        anchor_point = (i, j, __alnpos)
         op = OP_INVALID
     end)
+end
+
+# reverses the anchors sequence at the end of the traceback
+# and offsets the alignment positions, so that (by default) it starts from 0
+function reverse_anchors!(v::AbstractVector{AlignmentAnchor},
+                          alignment_offset=!isempty(v) ? -v[end].alnpos : 0)
+    r = n = length(v)
+    @inbounds for i in 1:fld1(n, 2)
+        vr = v[r]
+        vi = v[i]
+        v[i] = AlignmentAnchor(vr.seqpos, vr.refpos, vr.alnpos + alignment_offset, vr.op)
+        (i != r) && (v[r] = AlignmentAnchor(vi.seqpos, vi.refpos, vi.alnpos + alignment_offset, vi.op))
+        r -= 1
+    end
+    return v
 end
 
 macro finish_traceback()
     esc(quote
         push!(anchors, AlignmentAnchor(anchor_point..., op))
-        push!(anchors, AlignmentAnchor(i, j, OP_START))
-        reverse!(anchors)
+        push!(anchors, AlignmentAnchor(i, j, __alnpos, OP_START))
+        reverse_anchors!(anchors)
         pop!(anchors)  # remove OP_INVALID
     end)
 end
@@ -51,8 +67,9 @@ macro anchor(ex)
         if op != $ex
             push!(anchors, AlignmentAnchor(anchor_point..., op))
             op = $ex
-            anchor_point = (i, j)
+            anchor_point = (i, j, __alnpos)
         end
+        __alnpos -= 1
         if ismatchop(op)
             i -= 1
             j -= 1

--- a/src/pairwise/algorithms/common.jl
+++ b/src/pairwise/algorithms/common.jl
@@ -39,8 +39,8 @@ end
 
 macro finish_traceback()
     esc(quote
-        push!(anchors, AlignmentAnchor(anchor_point, op))
-        push!(anchors, AlignmentAnchor((i, j), OP_START))
+        push!(anchors, AlignmentAnchor(anchor_point..., op))
+        push!(anchors, AlignmentAnchor(i, j, OP_START))
         reverse!(anchors)
         pop!(anchors)  # remove OP_INVALID
     end)
@@ -49,7 +49,7 @@ end
 macro anchor(ex)
     esc(quote
         if op != $ex
-            push!(anchors, AlignmentAnchor(anchor_point, op))
+            push!(anchors, AlignmentAnchor(anchor_point..., op))
             op = $ex
             anchor_point = (i, j)
         end

--- a/src/pairwise/algorithms/hamming_distance.jl
+++ b/src/pairwise/algorithms/hamming_distance.jl
@@ -9,7 +9,7 @@
 function hamming_distance(::Type{T}, a, b) where T
     m = length(a)
     @assert m == length(b)
-    anchors = [AlignmentAnchor(0, 0, OP_START)]
+    anchors = [AlignmentAnchor(0, 0, 0, OP_START)]
     if m == 0
         # empty string
         return 0, anchors
@@ -19,17 +19,17 @@ function hamming_distance(::Type{T}, a, b) where T
     for i in 2:m
         if a[i] == b[i]
             if !was_match
-                push!(anchors, AlignmentAnchor(i - 1, i - 1, OP_SEQ_MISMATCH))
+                push!(anchors, AlignmentAnchor(i - 1, i - 1, i - 1, OP_SEQ_MISMATCH))
             end
             was_match = true
         else
             if was_match
-                push!(anchors, AlignmentAnchor(i - 1, i - 1, OP_SEQ_MATCH))
+                push!(anchors, AlignmentAnchor(i - 1, i - 1, i - 1, OP_SEQ_MATCH))
             end
             d += T(1)
             was_match = false
         end
     end
-    push!(anchors, AlignmentAnchor(m, m, was_match ? OP_SEQ_MATCH : OP_SEQ_MISMATCH))
+    push!(anchors, AlignmentAnchor(m, m, m, was_match ? OP_SEQ_MATCH : OP_SEQ_MISMATCH))
     return d, anchors
 end

--- a/src/pairwise/alignment.jl
+++ b/src/pairwise/alignment.jl
@@ -70,7 +70,7 @@ Count the number of positions where the `target` operation is applied.
 function Base.count(aln::PairwiseAlignment, target::Operation)
     anchors = aln.a.aln.anchors
     n = 0
-    for i in 2:lastindex(anchors)
+    @inbounds for i in 2:lastindex(anchors)
         op = anchors[i].op
         if op == target
             if ismatchop(op) || isinsertop(op)

--- a/src/pairwise/alignment.jl
+++ b/src/pairwise/alignment.jl
@@ -118,16 +118,7 @@ Count the number of aligned positions.
 """
 function count_aligned(aln::PairwiseAlignment)
     anchors = aln.a.aln.anchors
-    n = 0
-    for i in 2:lastindex(anchors)
-        op = anchors[i].op
-        if ismatchop(op) || isinsertop(op)
-            n += anchors[i].seqpos - anchors[i-1].seqpos
-        elseif isdeleteop(op)
-            n += anchors[i].refpos - anchors[i-1].refpos
-        end
-    end
-    return n
+    return isempty(anchors) ? 0 : last(anchors).alnpos
 end
 
 seq2ref(aln::PairwiseAlignment, i::Integer) = seq2ref(aln.a, i)

--- a/src/pairwise/alignment.jl
+++ b/src/pairwise/alignment.jl
@@ -132,6 +132,10 @@ end
 
 seq2ref(aln::PairwiseAlignment, i::Integer) = seq2ref(aln.a, i)
 ref2seq(aln::PairwiseAlignment, i::Integer) = ref2seq(aln.a, i)
+seq2aln(aln::PairwiseAlignment, i::Integer) = seq2aln(aln.a, i)
+ref2aln(aln::PairwiseAlignment, i::Integer) = ref2aln(aln.a, i)
+aln2seq(aln::PairwiseAlignment, i::Integer) = aln2seq(aln.a, i)
+aln2ref(aln::PairwiseAlignment, i::Integer) = aln2ref(aln.a, i)
 
 
 # Printers

--- a/src/pairwise/alignment.jl
+++ b/src/pairwise/alignment.jl
@@ -130,23 +130,8 @@ function count_aligned(aln::PairwiseAlignment)
     return n
 end
 
-"""
-    seq2ref(aln::PairwiseAlignment, i::Integer)::Tuple{Int,Operation}
-
-Map a position `i` from the first sequence to the second.
-"""
-function seq2ref(aln::PairwiseAlignment, i::Integer)::Tuple{Int,Operation}
-    return seq2ref(aln.a, i)
-end
-
-"""
-    ref2seq(aln::PairwiseAlignment, i::Integer)::Tuple{Int,Operation}
-
-Map a position `i` from the second sequence to the first.
-"""
-function ref2seq(aln::PairwiseAlignment, i::Integer)::Tuple{Int,Operation}
-    return ref2seq(aln.a, i)
-end
+seq2ref(aln::PairwiseAlignment, i::Integer) = seq2ref(aln.a, i)
+ref2seq(aln::PairwiseAlignment, i::Integer) = ref2seq(aln.a, i)
 
 
 # Printers

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,10 +34,11 @@ function random_alignment(m, n, glob=true)
         j_end = rand(j+1:n)
     end
 
-    path = AlignmentAnchor[AlignmentAnchor(i, j, OP_START)]
+    alnpos = 0
+    path = AlignmentAnchor[AlignmentAnchor(i, j, alnpos, OP_START)]
     while (glob && i < i_end && j < j_end) || (!glob && (i < i_end || j < j_end))
         straight = rand() < straight_pr
-
+        iprev, jprev = i, j
         if i == i_end
             if !straight
                 op = rand(delete_ops)
@@ -62,7 +63,8 @@ function random_alignment(m, n, glob=true)
                 j += 1
             end
         end
-        push!(path, AlignmentAnchor(i, j, op))
+        alnpos += max(i - iprev, j - jprev)
+        push!(path, AlignmentAnchor(i, j, alnpos, op))
     end
 
     return path
@@ -120,15 +122,15 @@ end
     end
 
     @testset "AlignmentAnchor" begin
-        anchor = AlignmentAnchor(1, 2, OP_MATCH)
-        @test string(anchor) == "AlignmentAnchor(1, 2, 'M')"
+        anchor = AlignmentAnchor(1, 2, 3, OP_MATCH)
+        @test string(anchor) == "AlignmentAnchor(1, 2, 3, 'M')"
     end
 
     @testset "Alignment" begin
         # alignments with nonsense operations
         @test_throws Exception Alignment(AlignmentAnchor[
-            Operation(0, 0, OP_START),
-            Operation(100, 100, convert(Operation, 0xfa))])
+            Operation(0, 0, 0, OP_START),
+            Operation(100, 100, 100, convert(Operation, 0xfa))])
 
         # test bad alignment anchors by swapping nodes in paths
         for _ in 1:100
@@ -157,8 +159,8 @@ end
                (isdeleteop(u.op) && isdeleteop(v.op))
                 continue
             end
-            anchors[i] = AlignmentAnchor(u.seqpos, u.refpos, v.op)
-            anchors[j] = AlignmentAnchor(v.seqpos, v.refpos, u.op)
+            anchors[i] = AlignmentAnchor(u.seqpos, u.refpos, u.alnpos, v.op)
+            anchors[j] = AlignmentAnchor(v.seqpos, v.refpos, v.alnpos, u.op)
             @test_throws Exception Alignment(anchors)
         end
 
@@ -181,31 +183,50 @@ end
         #               |   |   |    |     |  |   |
         #               4   8   12   17    20 23  27
         anchors = [
-            AlignmentAnchor( 0,  4, OP_START),
-            AlignmentAnchor( 4,  8, OP_MATCH),
-            AlignmentAnchor( 4, 12, OP_DELETE),
-            AlignmentAnchor( 9, 17, OP_MATCH),
-            AlignmentAnchor(12, 17, OP_INSERT),
-            AlignmentAnchor(15, 20, OP_MATCH),
-            AlignmentAnchor(15, 23, OP_DELETE),
-            AlignmentAnchor(19, 27, OP_MATCH)
+            AlignmentAnchor( 0,  4,  0, OP_START),
+            AlignmentAnchor( 4,  8,  4, OP_MATCH),
+            AlignmentAnchor( 4, 12,  8, OP_DELETE),
+            AlignmentAnchor( 9, 17, 13, OP_MATCH),
+            AlignmentAnchor(12, 17, 16, OP_INSERT),
+            AlignmentAnchor(15, 20, 19, OP_MATCH),
+            AlignmentAnchor(15, 23, 22, OP_DELETE),
+            AlignmentAnchor(19, 27, 26, OP_MATCH)
         ]
         query = "TGGCATCATTTAACGCAAG"
         alnseq = AlignedSequence(query, anchors)
         @test BioAlignments.first(alnseq) ==  5
         @test BioAlignments.last(alnseq)  == 27
         # OP_MATCH
-        for (seqpos, refpos) in [(1, 5), (2, 6), (4, 8), (13, 18), (19, 27)]
+        for (seqpos, refpos, alnpos) in [(1, 5, 1), (2, 6, 2), (4, 8, 4), (13, 18, 17), (19, 27, 26)]
             @test seq2ref(alnseq, seqpos) == (refpos, OP_MATCH)
             @test ref2seq(alnseq, refpos) == (seqpos, OP_MATCH)
+            @test seq2aln(alnseq, seqpos) == (alnpos, OP_MATCH)
+            @test ref2aln(alnseq, refpos) == (alnpos, OP_MATCH)
+            @test aln2seq(alnseq, alnpos) == (seqpos, OP_MATCH)
+            @test aln2ref(alnseq, alnpos) == (refpos, OP_MATCH)
         end
         # OP_INSERT
         @test seq2ref(alnseq, 10) == (17, OP_INSERT)
         @test seq2ref(alnseq, 11) == (17, OP_INSERT)
+        @test seq2aln(alnseq, 10) == (14, OP_INSERT)
+        @test seq2aln(alnseq, 11) == (15, OP_INSERT)
+        @test aln2seq(alnseq, 14) == (10, OP_INSERT)
+        @test aln2seq(alnseq, 15) == (11, OP_INSERT)
+        @test aln2ref(alnseq, 14) == (17, OP_INSERT)
+        @test aln2ref(alnseq, 15) == (17, OP_INSERT)
         # OP_DELETE
         @test ref2seq(alnseq,  9) == ( 4, OP_DELETE)
         @test ref2seq(alnseq, 10) == ( 4, OP_DELETE)
+        @test ref2aln(alnseq, 9) == (5, OP_DELETE)
+        @test ref2aln(alnseq, 10) == (6, OP_DELETE)
+        @test aln2seq(alnseq, 5) == (4, OP_DELETE)
+        @test aln2seq(alnseq, 6) == (4, OP_DELETE)
+        @test aln2ref(alnseq, 5) == (9, OP_DELETE)
+        @test aln2ref(alnseq, 6) == (10, OP_DELETE)
         @test ref2seq(alnseq, 23) == (15, OP_DELETE)
+        @test ref2aln(alnseq, 23) == (22, OP_DELETE)
+        @test aln2seq(alnseq, 22) == (15, OP_DELETE)
+        @test aln2ref(alnseq, 22) == (23, OP_DELETE)
         @test sprint(show, alnseq) == """
         ·············---··········
         TGGC----ATCATTTAACG---CAAG"""
@@ -216,14 +237,14 @@ end
         @test BioAlignments.first(alnseq) == 1
         @test BioAlignments.last(alnseq)  == 9
         @test alnseq.aln.anchors == [
-             AlignmentAnchor( 0, 0, '0')
-             AlignmentAnchor( 1, 0, 'I')
-             AlignmentAnchor( 4, 3, '=')
-             AlignmentAnchor( 4, 5, 'D')
-             AlignmentAnchor( 5, 6, 'X')
-             AlignmentAnchor( 9, 6, 'I')
-             AlignmentAnchor(11, 8, 'X')
-             AlignmentAnchor(12, 9, '=')
+             AlignmentAnchor( 0, 0,  0, '0')
+             AlignmentAnchor( 1, 0,  1, 'I')
+             AlignmentAnchor( 4, 3,  4, '=')
+             AlignmentAnchor( 4, 5,  6, 'D')
+             AlignmentAnchor( 5, 6,  7, 'X')
+             AlignmentAnchor( 9, 6, 11, 'I')
+             AlignmentAnchor(11, 8, 13, 'X')
+             AlignmentAnchor(12, 9, 14, '=')
         ]
         @test sprint(show, alnseq) == """
         -······----···
@@ -463,8 +484,8 @@ end
 
     @testset "Alignment" begin
         anchors = [
-            AlignmentAnchor(0, 0, OP_START),
-            AlignmentAnchor(3, 3, OP_SEQ_MATCH)
+            AlignmentAnchor(0, 0, 0, OP_START),
+            AlignmentAnchor(3, 3, 3, OP_SEQ_MATCH)
         ]
         seq = AlignedSequence("ACG", anchors)
         ref = "ACG"
@@ -485,16 +506,16 @@ end
         a = dna"ACGTGCAGAATTT"
         b = dna"AAAATTTGAAGTAT"
         anchors = [
-            AlignmentAnchor( 0,  0, '0'),
-            AlignmentAnchor( 1,  1, '='),
-            AlignmentAnchor( 3,  3, 'X'),
-            AlignmentAnchor( 3,  6, 'D'),
-            AlignmentAnchor( 5,  8, '='),
-            AlignmentAnchor( 6,  9, 'X'),
-            AlignmentAnchor( 8, 11, '='),
-            AlignmentAnchor( 9, 12, 'X'),
-            AlignmentAnchor(11, 14, '='),
-            AlignmentAnchor(13, 14, 'I')
+            AlignmentAnchor( 0,  0,  0, '0'),
+            AlignmentAnchor( 1,  1,  1, '='),
+            AlignmentAnchor( 3,  3,  3, 'X'),
+            AlignmentAnchor( 3,  6,  6, 'D'),
+            AlignmentAnchor( 5,  8,  8, '='),
+            AlignmentAnchor( 6,  9,  9, 'X'),
+            AlignmentAnchor( 8, 11, 11, '='),
+            AlignmentAnchor( 9, 12, 12, 'X'),
+            AlignmentAnchor(11, 14, 14, '='),
+            AlignmentAnchor(13, 14, 16, 'I')
         ]
         aln = PairwiseAlignment(AlignedSequence(a, anchors), b)
         @test count_matches(aln) == 7
@@ -518,9 +539,21 @@ end
         @test seq2ref(aln, 1) == (1, OP_SEQ_MATCH)
         @test seq2ref(aln, 2) == (3, OP_SEQ_MATCH)
         @test seq2ref(aln, 3) == (4, OP_SEQ_MATCH)
+        @test seq2aln(aln, 1) == (1, OP_SEQ_MATCH)
+        @test seq2aln(aln, 2) == (3, OP_SEQ_MATCH)
+        @test seq2aln(aln, 3) == (4, OP_SEQ_MATCH)
+        @test aln2seq(aln, 1) == (1, OP_SEQ_MATCH)
+        @test aln2seq(aln, 2) == (1, OP_DELETE)
+        @test aln2seq(aln, 3) == (2, OP_SEQ_MATCH)
         @test ref2seq(aln, 1) == (1, OP_SEQ_MATCH)
         @test ref2seq(aln, 2) == (1, OP_DELETE)
         @test ref2seq(aln, 3) == (2, OP_SEQ_MATCH)
+        @test ref2aln(aln, 1) == (1, OP_SEQ_MATCH)
+        @test ref2aln(aln, 2) == (2, OP_DELETE)
+        @test ref2aln(aln, 3) == (3, OP_SEQ_MATCH)
+        @test aln2ref(aln, 1) == (1, OP_SEQ_MATCH)
+        @test aln2ref(aln, 2) == (2, OP_DELETE)
+        @test aln2ref(aln, 3) == (3, OP_SEQ_MATCH)
     end
 
     @testset "GlobalAlignment" begin


### PR DESCRIPTION
# Alignment string position support

## Types of changes

This PR implements the following changes:

* [x] :sparkles: New feature (A non-breaking change which adds functionality).
* [ ] :bug: Bug fix (A non-breaking change, which fixes an issue).
* [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change).

## :clipboard: Additional detail

  - Mapping positions from/to the input or reference sequence onto the common alignment string is quite useful (e.g. when comparing annotations attached to specific positions of the aligned strings). In addition to `seq2ref()` and `ref2seq()`, this PR adds 4 new functions to the public API: `seq2agn`, `ref2agn`, `agn2seq`, `agn2ref`, which allow to convert between input/reference/alignment positions in any direction.

  - Technically, keeping track of alignment positions is implemented as an `AlignmentAnchor.agnpos` field. Updating the pairwise alignment algorithms to support alignment positions was easy, only the common traceback utility macros had to be changed. It also should not affect the performance or memory consumption.

  - I also did a few minor cleanups (`@inbounds` were beneficial, refactored position conversion to be more generic and using Julia 1.x approach (avoid generated functions, rely on constant propagation, argument splatting)).

  - **Provide a runnable example of use of your addition**. This lets reviewers
    and others try out the feature before it is merged or makes it's way to release.

## :ballot_box_with_check: Checklist

- [x] :art: The changes implemented is consistent with the [julia style guide](https://docs.julialang.org/en/stable/manual/style-guide/).
- [x] :blue_book: I have updated and added relevant docstrings, in a manner consistent with the [documentation styleguide](https://docs.julialang.org/en/stable/manual/documentation/).
- [ ] :blue_book: I have added or updated relevant user and developer manuals/documentation in `docs/src/`.
- [x] :ok: There are unit tests that cover the code changes I have made.
- [x] :ok: The unit tests cover my code changes AND they pass.
- [ ] :pencil: I have added an entry to the `[UNRELEASED]` section of the manually curated `CHANGELOG.md` file for this repository.
- [x] :ok: All changes should be compatible with the latest stable version of Julia.
- [x] :thought_balloon: I have commented liberally for any complex pieces of internal code.
