### PR TITLE
Remove BioJuliaRegistry

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -9,8 +9,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        julia-version: [1.3.0]
-        julia-arch: [x86]
+        julia-version: [1]
+        julia-arch: [x64]
         os: [ubuntu-latest]
     steps:
       - uses: julia-actions/setup-julia@latest

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,9 +1,12 @@
 name: TagBot
 on:
-  schedule:
-    - cron: '0 * * * *'
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
 jobs:
   TagBot:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
     runs-on: ubuntu-latest
     steps:
       - uses: JuliaRegistries/TagBot@v1

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -9,5 +9,3 @@ jobs:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ssh: ${{ secrets.TAGBOT_KEY }}
-          registry: BioJulia/BioJuliaRegistry

--- a/README.md
+++ b/README.md
@@ -13,18 +13,10 @@
 
 ## Installation
 
-BioAlignments is made available to install through BioJulia's package registry.
-By default, Julia's package manager only uses the "General" package registry.
-Your Julia configuration needs to include the BioJulia registry to be able to install the latest version of BioAlignments.
+You can install *BioAlignments.jl* from Julia REPL in [pkg mode](https://docs.julialang.org/en/v1/stdlib/Pkg/):
 
-To add the BioJulia registry from the [Julia REPL](https://docs.julialang.org/en/v1/manual/getting-started/), press `]` to enter [pkg mode](https://docs.julialang.org/en/v1/stdlib/Pkg/), then enter the following command:
-```julia
-registry add https://github.com/BioJulia/BioJuliaRegistry.git
 ```
-
-After adding the registry to your configuration, you can install BioAlignments while in [pkg mode](https://docs.julialang.org/en/v1/stdlib/Pkg/) with the following:
-```julia
-add BioAlignments
+pkg> add BioAlignments
 ```
 
 If you are interested in the cutting edge of the development, please check out the [develop branch](https://github.com/BioJulia/BioAlignments.jl/tree/develop) to try new features before release.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <img src="./sticker.svg" width="30%" align="right" /> BioAlignments
+# <img src="./sticker.svg" width="30%" align="right" /> BioAlignments.jl
 
 [![Latest release](https://img.shields.io/github/release/BioJulia/BioAlignments.jl.svg)](https://github.com/BioJulia/BioAlignments.jl/releases/latest)
 [![MIT license](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/BioJulia/BioAlignments.jl/blob/master/LICENSE)
@@ -7,11 +7,12 @@
 [![Project Status: Active](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
 [![Gitter](https://badges.gitter.im/BioJulia/BioAlignments.jl.svg)](https://gitter.im/BioJulia/BioAlignments.jl?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
-
 ## Description
-BioAlignments provides alignment algorithms and data structures.
+
+*BioAlignments.jl* provides sequence alignment algorithms and data structures.
 
 ## Installation
+
 BioAlignments is made available to install through BioJulia's package registry.
 By default, Julia's package manager only uses the "General" package registry.
 Your Julia configuration needs to include the BioJulia registry to be able to install the latest version of BioAlignments.
@@ -28,8 +29,8 @@ add BioAlignments
 
 If you are interested in the cutting edge of the development, please check out the [develop branch](https://github.com/BioJulia/BioAlignments.jl/tree/develop) to try new features before release.
 
-
 ## Testing
+
 BioAlignments is tested against Julia `1.X` on Linux, OS X, and Windows.
 
 **Latest build status:**
@@ -39,21 +40,24 @@ BioAlignments is tested against Julia `1.X` on Linux, OS X, and Windows.
 [![codecov](https://codecov.io/gh/BioJulia/BioAlignments.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/BioJulia/BioAlignments.jl)
 
 ## Contributing
+
 We appreciate [contributions](https://github.com/BioJulia/BioAlignments.jl/graphs/contributors) from users including reporting bugs, fixing issues, improving performance and adding new features.
 
 Take a look at the [contributing files](https://github.com/BioJulia/Contributing) detailed contributor and maintainer guidelines, and code of conduct.
 
 ### Special Thanks
+
 - Peter Haverty
   - GitHub [phaverty](https://github.com/phaverty)
 
 ### Financial contributions
+
 We also welcome financial contributions in full transparency on our [open collective](https://opencollective.com/biojulia).
 Anyone can file an expense.
 If the expense makes sense for the development of the community, it will be "merged" in the ledger of our open collective by the core contributors and the person who filed the expense will be reimbursed.
 
-
 ## Backers & Sponsors
+
 Thank you to all our backers and sponsors!
 
 Love our work and community? [Become a backer](https://opencollective.com/biojulia#backer).
@@ -75,4 +79,5 @@ Your logo will show up here with a link to your website.
 [![](https://opencollective.com/biojulia/sponsor/9/avatar.svg)](https://opencollective.com/biojulia/sponsor/9/website)
 
 ## Questions?
+
 If you have a question about contributing or using BioJulia software, come on over and chat to us on [Gitter](https://gitter.im/BioJulia/General), or you can try the [Bio category of the Julia discourse site](https://discourse.julialang.org/c/domain/bio).

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -13,18 +13,10 @@
 
 ## Installation
 
-*BioAlignments.jl* is made available to install through BioJulia's package registry.
-By default, Julia's package manager only uses the "General" package registry.
-Your Julia configuration needs to include the BioJulia registry to be able to install the latest version of BioAlignments.
+You can install *BioAlignments.jl* from Julia REPL in [pkg mode](https://docs.julialang.org/en/v1/stdlib/Pkg/):
 
-To add the BioJulia registry from the [Julia REPL](https://docs.julialang.org/en/v1/manual/getting-started/), press `]` to enter [pkg mode](https://docs.julialang.org/en/v1/stdlib/Pkg/), then enter the following command:
-```julia
-registry add https://github.com/BioJulia/BioJuliaRegistry.git
 ```
-
-After adding the registry to your configuration, you can install BioAlignments while in [pkg mode](https://docs.julialang.org/en/v1/stdlib/Pkg/) with the following:
-```julia
-add BioAlignments
+pkg> add BioAlignments
 ```
 
 If you are interested in the cutting edge of the development, please check out the [develop branch](https://github.com/BioJulia/BioAlignments.jl/tree/develop) to try new features before release.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,4 +1,4 @@
-# BioAlignments
+# BioAlignments.jl
 
 [![Latest release](https://img.shields.io/github/release/BioJulia/BioAlignments.jl.svg)](https://github.com/BioJulia/BioAlignments.jl/releases/latest)
 [![MIT license](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/BioJulia/BioAlignments.jl/blob/master/LICENSE)
@@ -7,12 +7,13 @@
 [![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
 [![Gitter](https://badges.gitter.im/BioJulia/BioAlignments.jl.svg)](https://gitter.im/BioJulia/BioAlignments.jl?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
-
 ## Description
-BioAlignments provides alignment algorithms and data structures.
+
+*BioAlignments.jl* provides sequence alignment algorithms and data structures.
 
 ## Installation
-BioAlignments is made available to install through BioJulia's package registry.
+
+*BioAlignments.jl* is made available to install through BioJulia's package registry.
 By default, Julia's package manager only uses the "General" package registry.
 Your Julia configuration needs to include the BioJulia registry to be able to install the latest version of BioAlignments.
 
@@ -29,7 +30,8 @@ add BioAlignments
 If you are interested in the cutting edge of the development, please check out the [develop branch](https://github.com/BioJulia/BioAlignments.jl/tree/develop) to try new features before release.
 
 ## Testing
-BioAlignments is tested against Julia `1.X` on Linux, OS X, and Windows.
+
+*BioAlignments.jl* is tested against Julia `1.X` on Linux, OS X, and Windows.
 
 **Latest build status:**
 
@@ -38,17 +40,19 @@ BioAlignments is tested against Julia `1.X` on Linux, OS X, and Windows.
 [![codecov](https://codecov.io/gh/BioJulia/BioAlignments.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/BioJulia/BioAlignments.jl)
 
 ## Contributing
+
 We appreciate [contributions](https://github.com/BioJulia/BioAlignments.jl/graphs/contributors) from users including reporting bugs, fixing issues, improving performance and adding new features.
 
 Take a look at the [contributing files](https://github.com/BioJulia/Contributing) detailed contributor and maintainer guidelines, and code of conduct.
 
 ### Financial contributions
+
 We also welcome financial contributions in full transparency on our [open collective](https://opencollective.com/biojulia).
 Anyone can file an expense.
 If the expense makes sense for the development of the community, it will be "merged" in the ledger of our open collective by the core contributors and the person who filed the expense will be reimbursed.
 
-
 ## Backers & Sponsors
+
 Thank you to all our backers and sponsors!
 
 Love our work and community? [Become a backer](https://opencollective.com/biojulia#backer).
@@ -69,6 +73,6 @@ Your logo will show up here with a link to your website.
 [![](https://opencollective.com/biojulia/sponsor/8/avatar.svg)](https://opencollective.com/biojulia/sponsor/8/website)
 [![](https://opencollective.com/biojulia/sponsor/9/avatar.svg)](https://opencollective.com/biojulia/sponsor/9/website)
 
-
 ## Questions?
+
 If you have a question about contributing or using BioJulia software, come on over and chat to us on [Gitter](https://gitter.im/BioJulia/General), or you can try the [Bio category of the Julia discourse site](https://discourse.julialang.org/c/domain/bio).


### PR DESCRIPTION
BioJuliaRegistry is deprecated, so remove its traces from readme, docs & actions (plus some minor changes to github-actions).