### PR TITLE
Prepare for minor release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Updated CI to use GitHub actions (#47)
+- *master* set as the main development branch (#49, #50)
 
 ### Removed
 - :exclamation: Reverted the use of *BioJulia* registry,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,21 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+- Alignment position support (#44)
+
+### Changed
+- Updated CI to use GitHub actions (#47)
+
+### Removed
+- :exclamation: Reverted the use of *BioJulia* registry,
+  the package switched to [General Julia Registry](https://github.com/JuliaRegistries/General) (#48)
 
 ## [2.0.0]
 

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ IntervalTrees = "524e6230-43b7-53ae-be76-1e9e4d08d11b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
-julia = "0.7,1"
+julia = "1"
 BioGenerics = "0.1"
 BioSequences = "2"
 BioSymbols = "4"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You can install *BioAlignments.jl* from Julia REPL in [pkg mode](https://docs.ju
 pkg> add BioAlignments
 ```
 
-If you are interested in the cutting edge of the development, please check out the [develop branch](https://github.com/BioJulia/BioAlignments.jl/tree/develop) to try new features before release.
+If you are interested in the cutting edge of the development, please check out the [*master* branch](https://github.com/BioJulia/BioAlignments.jl/tree/master) to try new features before release.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ BioAlignments is tested against Julia `1.X` on Linux, OS X, and Windows.
 
 **Latest build status:**
 
-[![Build Status](https://travis-ci.org/BioJulia/BioAlignments.jl.svg?branch=master)](https://travis-ci.org/BioJulia/BioAlignments.jl)
+[![Build Status](https://github.com/BioJulia/BioAlignments.jl/workflows/CI/badge.svg)](https://github.com/BioJulia/BioAlignments.jl/actions)
 [![appveyor](https://ci.appveyor.com/api/projects/status/klkynmkr1tgd30gq/branch/master?svg=true)](https://ci.appveyor.com/project/Ward9250/bioalignments-jl/branch/master)
 [![codecov](https://codecov.io/gh/BioJulia/BioAlignments.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/BioJulia/BioAlignments.jl)
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -22,6 +22,6 @@ makedocs(
 
 deploydocs(
     repo = "github.com/BioJulia/BioAlignments.jl.git",
-    devbranch = "develop",
+    devbranch = "master",
     push_preview = true
 )

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -19,7 +19,7 @@ You can install *BioAlignments.jl* from Julia REPL in [pkg mode](https://docs.ju
 pkg> add BioAlignments
 ```
 
-If you are interested in the cutting edge of the development, please check out the [develop branch](https://github.com/BioJulia/BioAlignments.jl/tree/develop) to try new features before release.
+If you are interested in the cutting edge of the development, please check out the [*master* branch](https://github.com/BioJulia/BioAlignments.jl/tree/master) to try new features before release.
 
 ## Testing
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -27,7 +27,7 @@ If you are interested in the cutting edge of the development, please check out t
 
 **Latest build status:**
 
-[![Build Status](https://travis-ci.org/BioJulia/BioAlignments.jl.svg?branch=master)](https://travis-ci.org/BioJulia/BioAlignments.jl)
+[![Build Status](https://github.com/BioJulia/BioAlignments.jl/workflows/CI/badge.svg)](https://github.com/BioJulia/BioAlignments.jl/actions)
 [![appveyor](https://ci.appveyor.com/api/projects/status/klkynmkr1tgd30gq/branch/master?svg=true)](https://ci.appveyor.com/project/Ward9250/bioalignments-jl/branch/master)
 [![codecov](https://codecov.io/gh/BioJulia/BioAlignments.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/BioJulia/BioAlignments.jl)
 


### PR DESCRIPTION
It would be nice to tag a new minor release (*2.1.0*?), so I've done some preparatory work:
* reverted back to *master* as the main development branch. But it was just about changing the README and the Documenter script.
  There was no feedback on the matter in #49, but if there are concerns I can instead update the config to use the *develop* branch (at the moment not all relevant config parameters use *develop* as the main branch anyway).
* updated the build CI badge to use GH Actions status
* dropped 0.7 from *Project.toml*. Support for Julia v0.7 was declared dropped already in BioAlignments v2.0.0, but 0.7 still lingered in *Project.toml*.
* updated the changelog