### PR TITLE
Allow compact printing of alignments

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,18 +4,18 @@ authors = ["Kenta Sato <bicycle1885@gmail.com>", "Ben J. Ward <benjward@protonma
 version = "2.0.0"
 
 [deps]
-BioGenerics = "47718e42-2ac5-11e9-14af-e5595289c2ea" # Note: required for distance function.
+BioGenerics = "47718e42-2ac5-11e9-14af-e5595289c2ea"
 BioSequences = "7e6ae17a-c86d-528c-b3b9-7f778a29fe59"
 BioSymbols = "3c28c6f8-a34d-59c4-9654-267d177fcfa9"
 IntervalTrees = "524e6230-43b7-53ae-be76-1e9e4d08d11b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
-julia = "1"
 BioGenerics = "0.1"
 BioSequences = "2"
 BioSymbols = "4"
 IntervalTrees = "1"
+julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/pairwise/alignment.jl
+++ b/src/pairwise/alignment.jl
@@ -132,7 +132,13 @@ aln2ref(aln::PairwiseAlignment, i::Integer) = aln2ref(aln.a, i)
 # Printers
 # --------
 
-showshort(io::IO, aln::PairwiseAlignment) = print(io, summary(aln), "()")
+function showshort(io::IO, aln::PairwiseAlignment)
+	print(io, summary(aln), "(lengths=(",
+		length(aln.a.seq), ", ", length(aln.b),
+		")/", length(aln), ')'
+	)
+end
+
 Base.show(io::IO, aln::PairwiseAlignment) = showshort(io, aln)
 
 function Base.show(io::IO, ::MIME"text/plain", aln::PairwiseAlignment)

--- a/src/pairwise/alignment.jl
+++ b/src/pairwise/alignment.jl
@@ -132,9 +132,16 @@ aln2ref(aln::PairwiseAlignment, i::Integer) = aln2ref(aln.a, i)
 # Printers
 # --------
 
-function Base.show(io::IO, aln::PairwiseAlignment)
-    println(io, summary(aln), ':')
-    print(io, aln)
+showshort(io::IO, aln::PairwiseAlignment) = print(io, summary(aln), "()")
+Base.show(io::IO, aln::PairwiseAlignment) = showshort(io, aln)
+
+function Base.show(io::IO, ::MIME"text/plain", aln::PairwiseAlignment)
+    if get(io, :compact, false)
+        showshort(io, aln)
+    else
+        println(io, summary(aln), ':')
+        print(io, aln)
+    end
 end
 
 function Base.print(io::IO, aln::PairwiseAlignment)

--- a/src/pairwise/result.jl
+++ b/src/pairwise/result.jl
@@ -68,15 +68,24 @@ end
 # Printer
 # -------
 
+
 function Base.show(io::IO, aln::PairwiseAlignmentResult{T,S1,S2}) where {T,S1,S2}
-    println(io, summary(aln), ':')
-    if aln.isscore
-        print(io, "  score: ", aln.value)
+    print(io, summary(aln), '(', aln.isscore ? "score" : "distance", '=', aln.value, ')')
+end
+
+function Base.show(io::IO, ::MIME"text/plain", aln::PairwiseAlignmentResult{T,S1,S2}) where {T,S1,S2}
+    if get(io, :compact, false)
+        show(io, aln)
     else
-        print(io, "  distance: ", aln.value)
-    end
-    if hasalignment(aln)
-        println(io)
-        print(io, alignment(aln))
+        println(io, summary(aln), ':')
+        if aln.isscore
+            print(io, "  score: ", aln.value)
+        else
+            print(io, "  distance: ", aln.value)
+        end
+        if hasalignment(aln)
+            println(io)
+            print(io, alignment(aln))
+        end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1041,6 +1041,12 @@ end
                   | |||| | |
           ref: 49 CVVESSVLRA 58
         """
+        buf = IOBuffer()
+        print(buf, (aln,))
+        @test String(take!(buf)) == (
+        	"""(PairwiseAlignment{$seqtype,$(VERSION >= v"1.6" ? " " : "")$(seqtype)}""" *
+        	"""(lengths=(58, 58)/60),)"""
+        )
         # Result from EMBOSS Needle:
         # EMBOSS_001         1 EPVTSHPKAVSPTETK--PTEKGQHLPVSAPPKITQSLKAEASKDIAKLT     48
         #                      ||  ||||||||||||  ||||.|||||||||||||.|||||||:|||||

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1014,7 +1014,9 @@ end
         seqtype = VERSION >= v"1.6" ?
             "BioSequences.LongAminoAcidSeq" :
             "BioSequences.LongSequence{BioSequences.AminoAcidAlphabet}"
-        @test sprint(show, aln) ==
+        buf = IOBuffer()
+        show(buf, MIME"text/plain"(), aln)
+        @test String(take!(buf)) ==
         """
         PairwiseAlignment{$(seqtype),$(VERSION >= v"1.6" ? " " : "")$(seqtype)}:
           seq:  1 EPVTSHPKAVSPTETK--PTEKGQHLPVSAPPKITQSLKAEASKDIAKLTCAVESSALCA 58


### PR DESCRIPTION
This changes printing of `PairwiseAlignment` and `PairwiseAlignmentResult`, such that they are displayed compactly in vectors and other structs. (I was getting annoyed by having my terminal wrecked when printing vectors of alignments).

When compact, they are now displayed like this:
```
julia> [aln]
1-element Vector{PairwiseAlignment{LongDNASeq, LongDNASeq}}:
 PairwiseAlignment{LongDNASeq, LongDNASeq}()

julia> [alnresult]
1-element Vector{PairwiseAlignmentResult{Int64, LongDNASeq, LongDNASeq}}:
 PairwiseAlignmentResult{Int64, LongDNASeq, LongDNASeq}(score=15)
```

This does violate the principle that the thing being printed should contain all the relevant information in the object, but in this case, I think there is no way to do this.