### PR TITLE
Add support for 'meta' alignment operations (`OP_PAD` and `OP_HARD_CLIP`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - Alignment position support (#44)
+- Support for `P` CIGAR operation (#64)
+
+### Fixed
+- Hard clips no longer consume bases (#64)
 
 ## [2.3.0] - 2022-10-01
 

--- a/docs/src/alignments.md
+++ b/docs/src/alignments.md
@@ -107,7 +107,7 @@ format](https://samtools.github.io/hts-specs/SAMv1.pdf) and are stored in the
 | `OP_SKIP`            | delete             | (typically long) deletion from the reference, e.g. due to RNA splicing          |
 | `OP_SOFT_CLIP`       | insert             | sequence removed from the beginning or end of the query sequence but stored     |
 | `OP_HARD_CLIP`       | insert             | sequence removed from the beginning or end of the query sequence and not stored |
-| `OP_PAD`             | special            | not currently supported, but present for SAM/BAM compatibility                  |
+| `OP_PAD`             | special            | silent deletion from padded reference (not present in query or reference)       |
 | `OP_SEQ_MATCH`       | match              | match operation with matching sequence positions                                |
 | `OP_SEQ_MISMATCH`    | match              | match operation with mismatching sequence positions                             |
 | `OP_BACK`            | special            | not currently supported, but present for SAM/BAM compatibility                  |

--- a/src/BioAlignments.jl
+++ b/src/BioAlignments.jl
@@ -32,6 +32,7 @@ export
     ismatchop,
     isinsertop,
     isdeleteop,
+    ismetaop,
     cigar,
 
     # substitution matrices

--- a/src/alignment.jl
+++ b/src/alignment.jl
@@ -79,6 +79,10 @@ function Alignment(cigar::AbstractString, seqpos::Int=1, refpos::Int=1)
                 seqpos += n
             elseif isdeleteop(op)
                 refpos += n
+            elseif ismetaop(op)
+                # This operation consumes no bases, so counteract the alignment postion
+                # movement below
+                alnpos -= n
             else
                 error("The $(op) CIGAR operation is not yet supported.")
             end

--- a/src/alignment.jl
+++ b/src/alignment.jl
@@ -83,6 +83,7 @@ function Alignment(cigar::AbstractString, seqpos::Int=1, refpos::Int=1)
                 # Meta operations consume alignment positions, but not sequence or reference
                 # positions, so there is nothing to do here but prevent the "not supported"
                 # error
+                nothing
             else
                 error("The $(op) CIGAR operation is not yet supported.")
             end

--- a/src/alignment.jl
+++ b/src/alignment.jl
@@ -219,8 +219,8 @@ function check_alignment_anchors(anchors)
         end
     end
 
-    # Check if a soft clip has anything but hard clips and start anchors between them and
-    # the end of the alignment
+    # Soft clips must be at either end of the alignment, or alternatively can have hard
+    # clips between them and the ends of the alignment. Check to make sure this is true.
     for i in 3:lastindex(anchors)
         if anchors[i].op == OP_SOFT_CLIP
             # Check if this is the last operation, which is valid
@@ -242,8 +242,8 @@ function check_alignment_anchors(anchors)
                 prev_valid = prev_valid && (anchor.op == OP_START || anchor.op == OP_HARD_CLIP)
             end
 
-            # Check for invalid operations
-            if !(next_valid || prev_valid)
+            # Check if this soft clip is a valid starting clip or a valid ending clip
+            if !(next_valid || prev_valid) # Alternatively: !next_valid && !prev_valid
                 error("OP_SOFT_CLIP may only have OP_HARD_CLIP operations between it and the ends of the alignment")
             end
         end

--- a/src/alignment.jl
+++ b/src/alignment.jl
@@ -190,8 +190,6 @@ function cigar(aln::Alignment)
     if isempty(anchors)
         return ""
     end
-    seqpos = anchors[1].seqpos
-    refpos = anchors[1].refpos
     @assert anchors[1].op == OP_START
     out = IOBuffer()
     for i in 2:length(anchors)

--- a/src/alignment.jl
+++ b/src/alignment.jl
@@ -182,7 +182,8 @@ aln2ref(aln::Alignment, i::Integer) = pos2pos(aln, i, alnpos, refpos)
 
 Make a CIGAR string encoding of `aln`.
 
-This is not entirely lossless as it discards the alignments start positions.
+This is not entirely lossless as it discards the alignments start positions and any meta
+operations (e.g. pads and hard clips).
 """
 function cigar(aln::Alignment)
     anchors = aln.anchors
@@ -196,7 +197,9 @@ function cigar(aln::Alignment)
     for i in 2:length(anchors)
         n = max(anchors[i].seqpos - anchors[i-1].seqpos,
                 anchors[i].refpos - anchors[i-1].refpos)
-        print(out, n, convert(Char, anchors[i].op))
+        if n > 0
+            print(out, n, convert(Char, anchors[i].op))
+        end
     end
     return String(take!(out))
 end

--- a/src/alignment.jl
+++ b/src/alignment.jl
@@ -211,6 +211,13 @@ function check_alignment_anchors(anchors)
         error("Alignments must begin with on OP_START anchor.")
     end
 
+    # Check if a hard clip occurs in the middle of the alignment
+    for i in 3:lastindex(anchors)-1
+        if anchors[i].op == OP_HARD_CLIP
+            error("OP_HARD_CLIP can only be present as the first (after OP_START) and/or last operation")
+        end
+    end
+
     for i in 2:lastindex(anchors)
         @inbounds acur, aprev = anchors[i], anchors[i-1]
         if acur.refpos < aprev.refpos || acur.seqpos < aprev.seqpos || acur.alnpos < aprev.alnpos

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -47,7 +47,7 @@ for (name, char, doc, code) in [
         ("SKIP"        , 'N', "(typically long) deletion from the reference, e.g. due to RNA splicing"         , 0x03),
         ("SOFT_CLIP"   , 'S', "sequence removed from the beginning or end of the query sequence but stored"    , 0x04),
         ("HARD_CLIP"   , 'H', "sequence removed from the beginning or end of the query sequence and not stored", 0x05),
-        ("PAD"         , 'P', "not currently supported, but present for SAM/BAM compatibility"                 , 0x06),
+        ("PAD"         , 'P', "silent deletion from padded reference (not present in query or reference)"      , 0x06),
         ("SEQ_MATCH"   , '=', "match operation with matching sequence positions"                               , 0x07),
         ("SEQ_MISMATCH", 'X', "match operation with mismatching sequence positions"                            , 0x08),
         ("BACK"        , 'B', "not currently supported, but present for SAM/BAM compatibility"                 , 0x09),

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -94,6 +94,16 @@ function isdeleteop(op::Operation)
     return op == OP_DELETE || op == OP_SKIP
 end
 
+"""
+    ismetaop(op::Operation)
+
+Test if `op` is a meta operation and does not consume reference or sequence bases (i.e.
+`op ∈ (OP_PAD, OP_HARD_CLIP)`).
+"""
+function ismetaop(op::Operation)
+    return op == OP_PAD || op == OP_HARD_CLIP
+end
+
 function Base.convert(::Type{Operation}, c::Char)
     i = convert(Int, c)
     @inbounds op = i < 128 ? char_to_op[i+1] : OP_INVALID

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -79,10 +79,10 @@ end
 """
     isinsertop(op::Operation)
 
-Test if `op` is a insertion operation (i.e. `op ∈ (OP_INSERT, OP_SOFT_CLIP, OP_HARD_CLIP)`).
+Test if `op` is a insertion operation (i.e. `op ∈ (OP_INSERT, OP_SOFT_CLIP)`).
 """
 function isinsertop(op::Operation)
-    return op == OP_INSERT || op == OP_SOFT_CLIP || op == OP_HARD_CLIP
+    return op == OP_INSERT || op == OP_SOFT_CLIP
 end
 
 """

--- a/src/pairwise/alignment.jl
+++ b/src/pairwise/alignment.jl
@@ -37,6 +37,19 @@ function Base.iterate(aln::PairwiseAlignment, ij=(2,1))
 
     anchors = aln.a.aln.anchors
     anchor = anchors[i]
+
+    # If this is a meta-operation, then advance to the next non-meta anchor, if available
+    # If there are no non-meta anchors left, then the iterator is finished
+    for k in i:lastindex(anchors)
+        i = k
+        anchor = anchors[i]
+        if !ismetaop(anchor.op)
+            break
+        elseif i == lastindex(anchors)
+            return nothing
+        end
+    end
+
     seq = aln.a.seq
     ref = aln.b
     seqpos = anchors[i-1].seqpos

--- a/src/pairwise/alignment.jl
+++ b/src/pairwise/alignment.jl
@@ -133,7 +133,16 @@ Count the number of aligned positions.
 """
 function count_aligned(aln::PairwiseAlignment)
     anchors = aln.a.aln.anchors
-    return isempty(anchors) ? 0 : last(anchors).alnpos
+    n = 0
+    for i in 2:lastindex(anchors)
+        op = anchors[i].op
+        if ismatchop(op) || isinsertop(op)
+            n += anchors[i].seqpos - anchors[i-1].seqpos
+        elseif isdeleteop(op)
+            n += anchors[i].refpos - anchors[i-1].refpos
+        end
+    end
+    return n
 end
 
 seq2ref(aln::PairwiseAlignment, i::Integer) = seq2ref(aln.a, i)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,32 +42,22 @@ function random_alignment(m, n, glob=true)
     while (glob && i < i_end && j < j_end) || (!glob && (i < i_end || j < j_end))
         straight = rand() < straight_pr
         iprev, jprev = i, j
-        if i == i_end
-            if !straight
-                op = rand(delete_ops)
-            end
-            j += 1
-        elseif j == j_end
-            if !straight
-                op = rand(insert_ops)
-            end
-            i += 1
-        else
-            if !straight
-                op = rand(ops)
-            end
 
-            if isdeleteop(op)
-                j += 1
-            elseif isinsertop(op)
-                i += 1
-            elseif ismetaop(op)
-                # Don't increment anything here
-            else
-                i += 1
-                j += 1
-            end
+        if !straight
+            op = rand(ops)
         end
+
+        if isdeleteop(op)
+            j += 1
+        elseif isinsertop(op)
+            i += 1
+        elseif ismetaop(op)
+            # Don't increment anything here
+        else
+            i += 1
+            j += 1
+        end
+
         alnpos_inc = max(i - iprev, j - jprev)
         alnpos += alnpos_inc > 0 ? alnpos_inc : rand(1:min(m,n))
         push!(path, AlignmentAnchor(i, j, alnpos, op))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,7 @@ function random_alignment(m, n, glob=true)
     insert_ops = [OP_INSERT]
     delete_ops = [OP_DELETE, OP_SKIP]
     meta_ops = [OP_PAD]
+    clip_ops = [OP_HARD_CLIP, OP_SOFT_CLIP]
     ops = vcat(match_ops, insert_ops, delete_ops, meta_ops)
 
     # This is just a random walk on a m-by-n matrix, where steps are either
@@ -76,6 +77,17 @@ function random_alignment(m, n, glob=true)
         push!(path, AlignmentAnchor(i, j, alnpos, op))
     end
 
+    # Randomly add a clip as the last operation
+    if rand(Bool)
+        iprev, jprev = i, j
+        op = rand(clip_ops)
+        if isinsertop(op)
+            i += 1
+        end
+        alnpos_inc = max(i - iprev, j - jprev)
+        alnpos += alnpos_inc > 0 ? alnpos_inc : rand(1:min(m,n))
+        push!(path, AlignmentAnchor(i, j, alnpos, op))
+    end
     return path
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,7 +48,7 @@ function random_alignment(m, n, glob=true)
             j += 1
         elseif j == j_end
             if !straight
-                op = rand(inset_ops)
+                op = rand(insert_ops)
             end
             i += 1
         else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -88,6 +88,14 @@ function random_alignment(m, n, glob=true)
         alnpos += alnpos_inc > 0 ? alnpos_inc : rand(1:min(m,n))
         push!(path, AlignmentAnchor(i, j, alnpos, op))
     end
+
+    # Randomly add a hard clip as the last operation if the last operation was a soft clip
+    if rand(Bool) && last(path).op == OP_SOFT_CLIP
+        op = OP_HARD_CLIP
+        alnpos += rand(1:min(m,n))
+        push!(path, AlignmentAnchor(i, j, alnpos, op))
+    end
+
     return path
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,7 +10,7 @@ import BioSequences: @dna_str, @aa_str
 # alignment.
 function random_alignment(m, n, glob=true)
     match_ops = [OP_MATCH, OP_SEQ_MATCH, OP_SEQ_MISMATCH]
-    insert_ops = [OP_INSERT, OP_SOFT_CLIP, OP_HARD_CLIP]
+    insert_ops = [OP_INSERT, OP_SOFT_CLIP]
     delete_ops = [OP_DELETE, OP_SKIP]
     ops = vcat(match_ops, insert_ops, delete_ops)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -50,6 +50,12 @@ function random_alignment(m, n, glob=true)
         straight = rand() < straight_pr
         iprev, jprev = i, j
 
+        # If the last operation was a hard clip, then we can make this a soft clip, but the
+        # straightness simulator takes priority again
+        if last(path).op == OP_HARD_CLIP && rand(Bool)
+            op = OP_SOFT_CLIP
+        end
+
         if !straight
             op = rand(ops)
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,6 +39,13 @@ function random_alignment(m, n, glob=true)
 
     alnpos = 0
     path = AlignmentAnchor[AlignmentAnchor(i, j, alnpos, OP_START)]
+
+    # If this is the first anchor, we can make it a hard clip, but we'll let the
+    # straightness simulator override it if it wants
+    if rand(Bool)
+        op = OP_HARD_CLIP
+    end
+
     while (glob && i < i_end && j < j_end) || (!glob && (i < i_end || j < j_end))
         straight = rand() < straight_pr
         iprev, jprev = i, j

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -542,6 +542,20 @@ end
         @test hasalignment(result) == true
     end
 
+    @testset "PaddedAlignment" begin
+        anchors = [
+            AlignmentAnchor(0, 0, 0, OP_START),
+            AlignmentAnchor(2, 2, 2, OP_SEQ_MATCH),
+            AlignmentAnchor(2, 2, 3, OP_PAD),
+            AlignmentAnchor(3, 3, 4, OP_SEQ_MATCH),
+            AlignmentAnchor(3, 3, 5, OP_HARD_CLIP),
+        ]
+        seq = AlignedSequence("ACG", anchors)
+        ref = "ACG"
+        aln = PairwiseAlignment(seq, ref)
+        @test collect(aln) == [('A', 'A'), ('C', 'C'), ('G', 'G')]
+    end
+
     @testset "count_<ops>" begin
         # anchors are derived from an alignment:
         #   seq: ACG---TGCAGAATTT

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,7 +10,7 @@ import BioSequences: @dna_str, @aa_str
 # alignment.
 function random_alignment(m, n, glob=true)
     match_ops = [OP_MATCH, OP_SEQ_MATCH, OP_SEQ_MISMATCH]
-    insert_ops = [OP_INSERT, OP_SOFT_CLIP]
+    insert_ops = [OP_INSERT]
     delete_ops = [OP_DELETE, OP_SKIP]
     ops = vcat(match_ops, insert_ops, delete_ops)
 


### PR DESCRIPTION
## Types of changes

This PR implements the following changes:

* [x] :sparkles: New feature (A non-breaking change which adds functionality).
* [x] :bug: Bug fix (A non-breaking change, which fixes an issue).
* [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change).

## :clipboard: Additional detail

Adds support for the `OP_PAD` operation, and fixes the implementation of the `OP_HARD_CLIP` operation. I have dubbed these two operations 'meta' operations, as they contain information about the origin and context of the alignment, but have no bearing on the content (i.e. reference or query) of the alignment.

### New features

1. Added function `ismetaop`, which returns `true` if passed `OP_PAD` or `OP_HARD_CLIP`
2. Creating an alignment with a `OP_PAD` operation no longer throws an error
3. Added validity check for `OP_HARD_CLIP` or `OP_SOFT_CLIP` in the wrong place
    According to the [SAM specification], these have to be present at the end of an alignment, with soft clips optionally buffering hard clips from the rest of the alignment

### Changed functionality

1. `cigar(::Alignment)` now uses the `AlignmentAnchor.alnpos` to print operation length
2. `OP_HARD_CLIP` is no longer considered an insert operation, and `isinsertop(OP_HARD_CLIP)` now returns `false`
3. The help text for `OP_PAD` indicates it's supported now
4. Trying to create an alignment with a hard or soft clip in an improper place will throw an error
    (I know I said this above, but it's probably the most likely addition to break something, even though it does conform to spec)

### Justification

BioAlignments should be able to handle all of the operations defined by the [SAM specification]. As it currently is, BioAlignments is unable even to parse the alignments in Section 1.1 "An example" of the specification. While the work on clips may seem out-of-scope for a change adding an operation support, the way clips work and pads work are very similar and needed to be considered together.

### Example

Using query sequence "r002" from Section 1.1 of the [SAM specification]:

#### BioAlignments 2.0.0

```julia-repl
julia> using BioAlignments

julia> Alignment("3S6M1P1I4M", 1, 9)
ERROR: The P CIGAR operation is not yet supported.
Stacktrace:
 [1] Alignment(cigar::String, seqpos::Int64, refpos::Int64)
...
```

#### This PR

```julia-repl
julia> using BioAlignments

julia> Alignment("3S6M1P1I4M", 1, 9)
Alignment:
  aligned range:
    seq: 0-14
    ref: 8-18
  CIGAR string: 3S6M1P1I4M
```

My testing also indicates that this fixes #56,

#### BioAlignments 2.0.0

```julia-repl
julia> using BioAlignments, BioSequences

julia> aligned_sequence = AlignedSequence(dna"AGAAGTTTATCTGTGTGAACTTCTTGGCTTAGTATCGTTGAGAAGAATCGAGAGATTAGTGCAGTTTAAA",
       Alignment("75H25M75H", 1, 1))
---------------------------------------------------------------------------·························---------------------------------------------------------------------------
AGAAGTTTATCTGTGTGAACTTCTTGGCTTAGTATCGTTGAGAAGAATCGAGAGATTAGTGCAGTTTAAAError showing value of type AlignedSequence{LongDNASeq}:
ERROR: BoundsError: attempt to access LongDNASeq at index [71]
Stacktrace:
...
```

#### This PR

```julia-repl
julia> using BioAlignments, BioSequences

julia> aligned_sequence = AlignedSequence(dna"AGAAGTTTATCTGTGTGAACTTCTTGGCTTAGTATCGTTGAGAAGAATCGAGAGATTAGTGCAGTTTAAA",
              Alignment("75H25M75H", 1, 1))
·························
AGAAGTTTATCTGTGTGAACTTCTT
```

## :ballot_box_with_check: Checklist

- [x] :art: The changes implemented is consistent with the [julia style guide](https://docs.julialang.org/en/stable/manual/style-guide/).
- [x] :blue_book: I have updated and added relevant docstrings, in a manner consistent with the [documentation styleguide](https://docs.julialang.org/en/stable/manual/documentation/).
- [x] :blue_book: I have added or updated relevant user and developer manuals/documentation in `docs/src/`.
- [x] :ok: There are unit tests that cover the code changes I have made.
- [x] :ok: The unit tests cover my code changes AND they pass.
- [x] :pencil: I have added an entry to the `[UNRELEASED]` section of the manually curated `CHANGELOG.md` file for this repository.
- [x] :ok: All changes should be compatible with the latest stable version of Julia.
- [x] :thought_balloon: I have commented liberally for any complex pieces of internal code.

[SAM specification]: https://samtools.github.io/hts-specs/SAMv1.pdf