### PR TITLE
BioSequences v3 and BioSymbols v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
           - '1.6'
           - '1'
           - 'nightly'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - *master* set as the main development branch (#49, #50)
 - Updated chat links (#ebea200c)
 - Expanded test matrix, adding julia v1.6 (#77)
+- Incremented BioSequences compatibility to v3 (#72)
+- Incremented BioSymbols compatibility to v5 (#72)
+- Adjusted test matrix for minimum compatibility (#72)
+- Updated doctests (#72)
 
 ### Removed
 - :exclamation: Reverted the use of *BioJulia* registry,
   the package switched to [General Julia Registry](https://github.com/JuliaRegistries/General) (#48)
 - :exclamation: Removed Gitter chat links (#ebea200c)
+- :exclamation: Dropped support for julia less than v1.6 (#72)
 
 ### Fixed
 - Doctests (#78)

--- a/Project.toml
+++ b/Project.toml
@@ -12,8 +12,8 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
 BioGenerics = "0.1"
-BioSequences = "2"
-BioSymbols = "4"
+BioSequences = "3"
+BioSymbols = "5"
 IntervalTrees = "1"
 julia = "1"
 

--- a/docs/src/pairalign.md
+++ b/docs/src/pairalign.md
@@ -74,7 +74,7 @@ julia> s2 = dna"ACCTGGTATGATAGCG";
 julia> scoremodel = AffineGapScoreModel(EDNAFULL, gap_open=-5, gap_extend=-1);
 
 julia> res = pairalign(GlobalAlignment(), s1, s2, scoremodel)  # run pairwise alignment
-PairwiseAlignmentResult{Int64, BioSequences.LongDNASeq, BioSequences.LongDNASeq}:
+PairwiseAlignmentResult{Int64, BioSequences.LongSequence{BioSequences.DNAAlphabet{4}}, BioSequences.LongSequence{BioSequences.DNAAlphabet{4}}}:
   score: 13
   seq:  0 -CCTAGG------AGGG 10
            ||| ||      || |
@@ -85,7 +85,7 @@ julia> score(res)  # get the achieved score of this alignment
 13
 
 julia> aln = alignment(res)
-PairwiseAlignment{BioSequences.LongDNASeq, BioSequences.LongDNASeq}:
+PairwiseAlignment{BioSequences.LongSequence{BioSequences.DNAAlphabet{4}}, BioSequences.LongSequence{BioSequences.DNAAlphabet{4}}}:
   seq:  0 -CCTAGG------AGGG 10
            ||| ||      || |
   ref:  1 ACCT-GGTATGATAGCG 16
@@ -126,11 +126,11 @@ julia> collect(aln)  # pairwise alignment is iterable
  (DNA_G, DNA_C)
  (DNA_G, DNA_G)
 
-julia> LongDNASeq([x for (x, _) in aln])  # create aligned `s1` with gaps
+julia> LongDNA{4}([x for (x, _) in aln])  # create aligned `s1` with gaps
 17nt DNA Sequence:
 -CCTAGG------AGGG
 
-julia> LongDNASeq([y for (_, y) in aln])  # create aligned `s2` with gaps
+julia> LongDNA{4}([y for (_, y) in aln])  # create aligned `s2` with gaps
 17nt DNA Sequence:
 ACCT-GGTATGATAGCG
 

--- a/src/submat.jl
+++ b/src/submat.jl
@@ -137,12 +137,12 @@ end
 
 # Return the row/column index of `nt`.
 function index(nt::BioSymbols.NucleicAcid)
-    return convert(Int, nt)
+    return reinterpret(Int8, nt)
 end
 
 # Return the row/column index of `aa`.
 function index(aa::BioSymbols.AminoAcid)
-    return convert(Int, aa) + 1
+    return reinterpret(Int8, aa) + 1
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1012,15 +1012,12 @@ end
         seq2 = aa"EPSHPKAVSPTETKRCPTEKVQHLPVSAPPKITQFLKAEASKEIAKLTCVVESSVLRA"
         model = AffineGapScoreModel(BLOSUM62, gap_open=-10, gap_extend=-1)
         aln = alignment(pairalign(GlobalAlignment(), seq1, seq2, model))
-        # julia 1.6+ uses shorter type aliases when printing types
-        seqtype = VERSION >= v"1.6" ?
-            "BioSequences.LongAA" :
-            "BioSequences.LongSequence{BioSequences.AminoAcidAlphabet}"
+        seqtype = "BioSequences.LongAA"
         buf = IOBuffer()
         show(buf, MIME"text/plain"(), aln)
         @test String(take!(buf)) ==
         """
-        PairwiseAlignment{$(seqtype),$(VERSION >= v"1.6" ? " " : "")$(seqtype)}:
+        PairwiseAlignment{$seqtype, $seqtype}:
           seq:  1 EPVTSHPKAVSPTETK--PTEKGQHLPVSAPPKITQSLKAEASKDIAKLTCAVESSALCA 58
                   ||  ||||||||||||  |||| ||||||||||||| ||||||| |||||| |||| | |
           ref:  1 EP--SHPKAVSPTETKRCPTEKVQHLPVSAPPKITQFLKAEASKEIAKLTCVVESSVLRA 58
@@ -1046,7 +1043,7 @@ end
         buf = IOBuffer()
         print(buf, (aln,))
         @test String(take!(buf)) == (
-        	"""(PairwiseAlignment{$seqtype,$(VERSION >= v"1.6" ? " " : "")$(seqtype)}""" *
+        	"""(PairwiseAlignment{$seqtype, $seqtype}""" *
         	"""(lengths=(58, 58)/60),)"""
         )
         # Result from EMBOSS Needle:

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1014,7 +1014,7 @@ end
         aln = alignment(pairalign(GlobalAlignment(), seq1, seq2, model))
         # julia 1.6+ uses shorter type aliases when printing types
         seqtype = VERSION >= v"1.6" ?
-            "BioSequences.LongAminoAcidSeq" :
+            "BioSequences.LongAA" :
             "BioSequences.LongSequence{BioSequences.AminoAcidAlphabet}"
         buf = IOBuffer()
         show(buf, MIME"text/plain"(), aln)


### PR DESCRIPTION
This PR:
- increments dependency compatibilities (reimplements a reinterpret of BioSymbols);
- includes some doctests in the unit tests; and
- updates doctests for BioSequences v3 and BioSymbols v5 (adjusts a print width).
