### PR TITLE
Add getter methods (and forwarded getter methods) for alignment types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Getter functions for `AlignedSequence`, `PairwiseAlignment`, and
+  `PairwiseAlignmentResult`
+
 ## [2.2.0]
 
 ### Added

--- a/docs/src/alignments.md
+++ b/docs/src/alignments.md
@@ -177,3 +177,24 @@ julia> AlignedSequence(seq, ref)
 ACGT--AAT--
 
 ```
+
+You can get the underlying alignment and sequence back out of an
+`AlignedSequence` by using the `alignment` and `sequence` functions.
+
+```jldoctest
+julia> aln = AlignedSequence(dna"ACGT--AAT--", dna"ACGTTTAT-GG")
+········-··
+ACGT--AAT--
+
+julia> alignment(aln)
+Alignment:
+  aligned range:
+    seq: 0-7
+    ref: 0-10
+  CIGAR string: 4=2D1=1X1I2D
+
+julia> sequence(aln)
+7nt DNA Sequence:
+ACGTAAT
+
+```

--- a/docs/src/pairalign.md
+++ b/docs/src/pairalign.md
@@ -91,6 +91,9 @@ PairwiseAlignment{BioSequences.LongSequence{BioSequences.DNAAlphabet{4}}, BioSeq
            ||| ||      || |
   ref:  1 ACCT-GGTATGATAGCG 16
 
+julia> sequence(res)
+10nt DNA Sequence:
+CCTAGGAGGG
 
 julia> count_matches(aln)
 8

--- a/src/BioAlignments.jl
+++ b/src/BioAlignments.jl
@@ -69,7 +69,8 @@ export
     score,
     distance,
     alignment,
-    hasalignment
+    hasalignment,
+    sequence
 
 using BioGenerics
 import BioGenerics: distance

--- a/src/alignedseq.jl
+++ b/src/alignedseq.jl
@@ -60,6 +60,14 @@ function AlignedSequence(seq::BioSequences.BioSequence, seqpos::Integer,
     return AlignedSequence(newseq, anchors)
 end
 
+# Getter functions
+"""
+    alignment(aligned_sequence)
+
+Gets the [`Alignment`](@ref) of `aligned_sequence`.
+"""
+alignment(alnseq::AlignedSequence) = alnseq.aln
+
 # First position in the reference sequence.
 function IntervalTrees.first(alnseq::AlignedSequence)
     return alnseq.aln.firstref

--- a/src/alignedseq.jl
+++ b/src/alignedseq.jl
@@ -68,6 +68,13 @@ Gets the [`Alignment`](@ref) of `aligned_sequence`.
 """
 alignment(alnseq::AlignedSequence) = alnseq.aln
 
+"""
+    sequence(aligned_sequence)
+
+Return the sequence of `aligned_sequence`.
+"""
+sequence(alnseq::AlignedSequence) = alnseq.seq
+
 # First position in the reference sequence.
 function IntervalTrees.first(alnseq::AlignedSequence)
     return alnseq.aln.firstref

--- a/src/pairwise/alignment.jl
+++ b/src/pairwise/alignment.jl
@@ -14,6 +14,14 @@ mutable struct PairwiseAlignment{S1,S2}
     b::S2
 end
 
+# Getter functions
+"""
+    alignment(pairwise_alignment)
+
+Gets the underlying [`Alignment`](@ref) from `pairwise_alignment`.
+"""
+alignment(aln::PairwiseAlignment) = alignment(aln.a)
+
 function Base.iterate(aln::PairwiseAlignment, ij=(2,1))
     i, j = ij
     if i > lastindex(aln.a.aln.anchors)

--- a/src/pairwise/alignment.jl
+++ b/src/pairwise/alignment.jl
@@ -22,6 +22,13 @@ Gets the underlying [`Alignment`](@ref) from `pairwise_alignment`.
 """
 alignment(aln::PairwiseAlignment) = alignment(aln.a)
 
+"""
+    sequence(pairwise_alignment)
+
+Gets the query sequence of `pairwise_alignment`.
+"""
+sequence(aln::PairwiseAlignment) = sequence(aln.a)
+
 function Base.iterate(aln::PairwiseAlignment, ij=(2,1))
     i, j = ij
     if i > lastindex(aln.a.aln.anchors)

--- a/src/pairwise/result.jl
+++ b/src/pairwise/result.jl
@@ -64,6 +64,13 @@ function alignment(aln::PairwiseAlignmentResult)
     return aln.aln
 end
 
+"""
+    sequence(alignment_result)
+
+Return the query sequence of `alignment_result`, if it exists.
+"""
+sequence(aln::PairwiseAlignmentResult) = sequence(alignment(aln))
+
 
 # Printer
 # -------

--- a/src/pairwise/result.jl
+++ b/src/pairwise/result.jl
@@ -53,7 +53,10 @@ hasalignment(aln::PairwiseAlignmentResult) = aln.aln !== nothing
 """
     alignment(alignment_result)
 
-Return alignment if any.
+Return the alignment if any as a [`PairwiseAlignment`](@ref). To get the
+[`Alignment`](@ref), nest the function, e.g. `alignment(alignment(alignment_result))`.
+This function returns a `PairwiseAlignment` instead of an `Alignment` for
+backwards-compatibility reasons.
 
 See also: `hasalignment`
 """


### PR DESCRIPTION
## Types of changes

This PR implements the following changes:

* [x] :sparkles: New feature (A non-breaking change which adds functionality).
* [ ] :bug: Bug fix (A non-breaking change, which fixes an issue).
* [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change).

## :clipboard: Additional detail

The idea for these getter functions first came up in the discussion at https://github.com/BioJulia/BioAlignments.jl/discussions/80#discussioncomment-2959292. These functions are intended to be user-friendly band-aids over the disjointed API between `Alignment`, `AlignedSequence`, `PairwiseAlignment`, and `PairwiseAlignmentResult`. There are five new methods, with one new exported function.

- `alignment(::AlignedSequence) -> Alignment`
- `alignment(::PairwiseAlignment) -> Alignment`
- *new* `sequence(::AlignedSequence) -> LongSequence`
- *new* `sequence(::PairwiseAlignment) -> LongSequence`
- *new* `sequence(::PairwiseAlignmentResult) -> LongSequence`

Note that `alignment(::PairwiseAlignmentResult)` already returns a `PairwiseAlignment`. I opted for liberal documentation over breaking the API.

I added extra documentation and tests in the form of doctests. I didn't add any additional tests to the regular test suite, as getter function tests are pretty redundant.

My hope is that this closes out the feature list of BioAlignments v2, and we can get #44 merged and move on to BioAlignments v3 after this.

> _Note:_ I branched off of the hotfix/v2.2.0 branch, so this branch is out-of-date with master and will likely need merged manually. Another reason to move beyond #44.

## :ballot_box_with_check: Checklist

- [x] :art: The changes implemented is consistent with the [julia style guide](https://docs.julialang.org/en/stable/manual/style-guide/).
- [x] :blue_book: I have updated and added relevant docstrings, in a manner consistent with the [documentation styleguide](https://docs.julialang.org/en/stable/manual/documentation/).
- [x] :blue_book: I have added or updated relevant user and developer manuals/documentation in `docs/src/`.
- [x] :ok: There are unit tests that cover the code changes I have made.
- [x] :ok: The unit tests cover my code changes AND they pass.
- [x] :pencil: I have added an entry to the `[UNRELEASED]` section of the manually curated `CHANGELOG.md` file for this repository.
- [x] :ok: All changes should be compatible with the latest stable version of Julia.
- [x] :thought_balloon: I have commented liberally for any complex pieces of internal code.
